### PR TITLE
feat: clickable URLs in chat log

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+﻿[*]
+indent_style = space
+tab_width = 4
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/ChatTwo/Chunk.cs
+++ b/ChatTwo/Chunk.cs
@@ -59,6 +59,19 @@ internal class TextChunk : Chunk {
     public TextChunk() : base(ChunkSource.None, null) {
     }
     #pragma warning restore CS8618
+
+    /// <summary>
+    /// Creates a new TextChunk with identical styling to this one.
+    /// </summary>
+    public TextChunk NewWithStyle(ChunkSource source, Payload? link, string content)
+    {
+        return new TextChunk(source, link, content) {
+            FallbackColour = this.FallbackColour,
+            Foreground = this.Foreground,
+            Glow = this.Glow,
+            Italic = this.Italic,
+        };
+    }
 }
 
 internal class IconChunk : Chunk {

--- a/ChatTwo/PayloadHandler.cs
+++ b/ChatTwo/PayloadHandler.cs
@@ -21,6 +21,7 @@ using Lumina.Excel.GeneratedSheets;
 using Action = System.Action;
 using DalamudPartyFinderPayload = Dalamud.Game.Text.SeStringHandling.Payloads.PartyFinderPayload;
 using ChatTwoPartyFinderPayload = ChatTwo.Util.PartyFinderPayload;
+using System.Diagnostics;
 
 namespace ChatTwo;
 
@@ -83,6 +84,11 @@ public sealed class PayloadHandler {
             }
             case ItemPayload item: {
                 DrawItemPopup(item);
+                drawn = true;
+                break;
+            }
+            case URIPayload uri: {
+                DrawUriPopup(uri);
                 drawn = true;
                 break;
             }
@@ -215,6 +221,11 @@ public sealed class PayloadHandler {
                 DoHover(() => HoverItem(item), hoverSize);
                 break;
             }
+            case URIPayload uri:
+            {
+                DoHover(() => HoverURI(uri), hoverSize);
+                break;
+            }
         }
     }
 
@@ -334,6 +345,11 @@ public sealed class PayloadHandler {
         }
     }
 
+    private void HoverURI(URIPayload uri) {
+        ImGui.TextUnformatted(string.Format(Language.Context_URLDomain, uri.Uri.Authority));
+        ImGuiUtil.WarningText(Language.Context_URLWarning);
+    }
+
     private void LeftClickPayload(Chunk chunk, Payload? payload) {
         switch (payload) {
             case MapLinkPayload map: {
@@ -370,6 +386,10 @@ public sealed class PayloadHandler {
                     GameFunctions.GameFunctions.OpenPartyFinder();
                 }
 
+                break;
+            }
+            case URIPayload uri: {
+                TryOpenURI(uri.Uri);
                 break;
             }
         }
@@ -624,5 +644,39 @@ public sealed class PayloadHandler {
         }
 
         return null;
+    }
+
+    private void DrawUriPopup(URIPayload uri)
+    {
+        ImGui.TextUnformatted(string.Format(Language.Context_URLDomain, uri.Uri.Authority));
+        ImGuiUtil.WarningText(Language.Context_URLWarning, false);
+        ImGui.Separator();
+
+        if (ImGui.Selectable(Language.Context_OpenInBrowser))
+        {
+            TryOpenURI(uri.Uri);
+        }
+
+        if (ImGui.Selectable(Language.Context_CopyLink))
+        {
+            ImGui.SetClipboardText(uri.Uri.ToString());
+            WrapperUtil.AddNotification(Language.Context_CopyLinkNotification, NotificationType.Info);
+        }
+    }
+
+    private void TryOpenURI(Uri uri)
+    {
+        new Thread(() => {
+            try
+            {
+                Plugin.Log.Info($"Opening URI {uri} in default browser");
+                Process.Start(new ProcessStartInfo(uri.ToString()) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Plugin.Log.Error($"Error opening URI: {ex}");
+                WrapperUtil.AddNotification(Language.Context_OpenInBrowserError, NotificationType.Error);
+            }
+        }).Start();
     }
 }

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -1041,6 +1041,24 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy link to clipboard.
+        /// </summary>
+        internal static string Context_CopyLink {
+            get {
+                return ResourceManager.GetString("Context_CopyLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copied link to clipboard.
+        /// </summary>
+        internal static string Context_CopyLinkNotification {
+            get {
+                return ResourceManager.GetString("Context_CopyLinkNotification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide chat.
         /// </summary>
         internal static string Context_HideChat {
@@ -1122,6 +1140,24 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open link in browser.
+        /// </summary>
+        internal static string Context_OpenInBrowser {
+            get {
+                return ResourceManager.GetString("Context_OpenInBrowser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to open the link in the browser, please report this issue.
+        /// </summary>
+        internal static string Context_OpenInBrowserError {
+            get {
+                return ResourceManager.GetString("Context_OpenInBrowserError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Promote.
         /// </summary>
         internal static string Context_Promote {
@@ -1199,6 +1235,24 @@ namespace ChatTwo.Resources {
         internal static string Context_TryOn {
             get {
                 return ResourceManager.GetString("Context_TryOn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URL at {0}.
+        /// </summary>
+        internal static string Context_URLDomain {
+            get {
+                return ResourceManager.GetString("Context_URLDomain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only open URLs from websites you trust.
+        /// </summary>
+        internal static string Context_URLWarning {
+            get {
+                return ResourceManager.GetString("Context_URLWarning", resourceCulture);
             }
         }
         

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -871,4 +871,22 @@
     <data name="Options_TooltipOffset_Desc" xml:space="preserve">
         <value>Use this option if you experience cut-off tooltips.</value>
     </data>
+    <data name="Context_CopyLink" xml:space="preserve">
+        <value>Copy link to clipboard</value>
+    </data>
+    <data name="Context_CopyLinkNotification" xml:space="preserve">
+        <value>Copied link to clipboard</value>
+    </data>
+    <data name="Context_OpenInBrowser" xml:space="preserve">
+        <value>Open link in browser</value>
+    </data>
+    <data name="Context_OpenInBrowserError" xml:space="preserve">
+        <value>Failed to open the link in the browser, please report this issue</value>
+    </data>
+    <data name="Context_URLDomain" xml:space="preserve">
+        <value>URL at {0}</value>
+    </data>
+    <data name="Context_URLWarning" xml:space="preserve">
+        <value>Only open URLs from websites you trust</value>
+    </data>
 </root>

--- a/ChatTwo/Store.cs
+++ b/ChatTwo/Store.cs
@@ -86,6 +86,11 @@ internal class Store : IDisposable {
                             ["Type"] = new("PartyFinder"),
                             ["Id"] = new(partyFinder.Id),
                         });
+                    case URIPayload uri:
+                        return new BsonDocument(new Dictionary<string, BsonValue> {
+                            ["Type"] = new("URI"),
+                            ["Uri"] = new(uri.Uri.ToString()),
+                        });
                 }
 
                 return payload?.Encode();
@@ -99,6 +104,7 @@ internal class Store : IDisposable {
                     return bson["Type"].AsString switch {
                         "Achievement" => new AchievementPayload((uint) bson["Id"].AsInt64),
                         "PartyFinder" => new PartyFinderPayload((uint) bson["Id"].AsInt64),
+                        "URI" => new URIPayload(new Uri(bson["Uri"].AsString)),
                         _ => null,
                     };
                 }

--- a/ChatTwo/Util/ChunkUtil.cs
+++ b/ChatTwo/Util/ChunkUtil.cs
@@ -1,6 +1,7 @@
 using ChatTwo.Code;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using System.Text;
 
 namespace ChatTwo.Util;
 
@@ -100,6 +101,10 @@ internal static class ChunkUtil {
                         var reader = new BinaryReader(new MemoryStream(rawPayload.Data[4..]));
                         var id = GetInteger(reader);
                         link = new AchievementPayload(id);
+                    } else if (rawPayload.Data.Length > 5 && rawPayload.Data[1] == 0x27 && rawPayload.Data[3] == 0x07) {
+                        // uri payload
+                        var uri = new Uri(Encoding.UTF8.GetString(rawPayload.Data[4..]));
+                        link = new URIPayload(uri);
                     } else if (Equals(rawPayload, RawPayload.LinkTerminator)) {
                         link = null;
                     }

--- a/ChatTwo/Util/ImGuiUtil.cs
+++ b/ChatTwo/Util/ImGuiUtil.cs
@@ -197,16 +197,16 @@ internal static class ImGuiUtil {
         }
     }
 
-    internal static void WarningText(string text) {
+    internal static void WarningText(string text, bool wrap = true) {
         var style = StyleModel.GetConfiguredStyle() ?? StyleModel.GetFromCurrent();
         var dalamudOrange = style.BuiltInColors?.DalamudOrange;
         if (dalamudOrange != null) {
             ImGui.PushStyleColor(ImGuiCol.Text, dalamudOrange.Value);
         }
 
-        ImGui.PushTextWrapPos();
+        if (wrap) ImGui.PushTextWrapPos();
         ImGui.TextUnformatted(text);
-        ImGui.PopTextWrapPos();
+        if (wrap) ImGui.PopTextWrapPos();
 
         if (dalamudOrange != null) {
             ImGui.PopStyleColor();

--- a/ChatTwo/Util/Payloads.cs
+++ b/ChatTwo/Util/Payloads.cs
@@ -37,3 +37,51 @@ internal class AchievementPayload : Payload {
         throw new NotImplementedException();
     }
 }
+
+
+internal class URIPayload(Uri uri) : Payload
+{
+    public override PayloadType Type => (PayloadType) 0x52;
+
+    public Uri Uri { get; init; } = uri;
+
+    private static readonly string[] ExpectedSchemes = ["http", "https"];
+    private static readonly string DefaultScheme = "https";
+
+    /// <summary>
+    /// Create a URIPayload from a raw URI string. If the URI does not have a
+    /// scheme, it will default to https://.
+    /// </summary>
+    /// <exception cref="UriFormatException">
+    /// If the URI is invalid, or if the scheme is not supported.
+    /// </exception>
+    public static URIPayload ResolveURI(string rawURI)
+    {
+        ArgumentNullException.ThrowIfNull(rawURI);
+
+        // Check for expected scheme ://, if not add https://
+        foreach (var scheme in ExpectedSchemes)
+        {
+            if (rawURI.StartsWith($"{scheme}://"))
+            {
+                return new URIPayload(new Uri(rawURI));
+            }
+        }
+        if (rawURI.Contains("://"))
+        {
+            throw new UriFormatException($"Unsupported scheme in URL: {rawURI}");
+        }
+
+        return new URIPayload(new Uri($"{DefaultScheme}://{rawURI}"));
+    }
+
+    protected override void DecodeImpl(BinaryReader reader, long endOfStream)
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override byte[] EncodeImpl()
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Adds a parsing step when constructing `Message` objects that scans the message content for anything that looks URL-like, and inserts new `TextChunk`s into the message content with a URIPayload set.

Hovering over a URL shows an on-hover effect. Clicking a URL opens it in the default browser. Right clicking shows the hostname, with an option to open and an option to copy the URL to the clipboard.

This runs a regex on each received message once to find URLs. Since messages are cached in memory and in the database, the regex doesn't get run again when reloading the plugin.

The regex is a bit quirky but I think it's a good compromise for detecting most URLs. It'll match:
- any URL with a scheme (regardless of TLD): `https://anything.anything.blah/asda`
- any dot separated string starting with `www.` (regardless of TLD): `www.something.blah`
- any website with a common TLD `com|net|org|co|io|app`: `google.com`

I think only matching common TLDs is a good compromise to avoid linking random messages when people forget to put a space after a period. People can always add a scheme if they are using weird TLDs, or they can be added to the regex easily later.

Note: I don't know how to generate the language files so they're identical to yours, I just generated them in Visual Studio and ran `fix_resources.sh` from WSL.

https://github.com/Infiziert90/ChatTwo/assets/11241812/163f891e-11ac-49f2-944b-890df04976d3