### PR TITLE
feat: allow tab input channel to be set to ExtraChat

### DIFF
--- a/ChatTwo/Code/ChatType.cs
+++ b/ChatTwo/Code/ChatType.cs
@@ -84,4 +84,14 @@ internal enum ChatType : ushort {
     CrossLinkshell6 = 105,
     CrossLinkshell7 = 106,
     CrossLinkshell8 = 107,
+    
+    // Custom types:
+    ExtraChatLinkshell1 = 1001,
+    ExtraChatLinkshell2 = 1002,
+    ExtraChatLinkshell3 = 1003,
+    ExtraChatLinkshell4 = 1004,
+    ExtraChatLinkshell5 = 1005,
+    ExtraChatLinkshell6 = 1006,
+    ExtraChatLinkshell7 = 1007,
+    ExtraChatLinkshell8 = 1008,
 }

--- a/ChatTwo/Code/ChatTypeExt.cs
+++ b/ChatTwo/Code/ChatTypeExt.cs
@@ -162,6 +162,14 @@ internal static class ChatTypeExt {
             ChatType.CrossLinkshell6 => Language.ChatType_CrossLinkshell6,
             ChatType.CrossLinkshell7 => Language.ChatType_CrossLinkshell7,
             ChatType.CrossLinkshell8 => Language.ChatType_CrossLinkshell8,
+            ChatType.ExtraChatLinkshell1 => Language.ChatType_ExtraChatLinkshell1,
+            ChatType.ExtraChatLinkshell2 => Language.ChatType_ExtraChatLinkshell2,
+            ChatType.ExtraChatLinkshell3 => Language.ChatType_ExtraChatLinkshell3,
+            ChatType.ExtraChatLinkshell4 => Language.ChatType_ExtraChatLinkshell4,
+            ChatType.ExtraChatLinkshell5 => Language.ChatType_ExtraChatLinkshell5,
+            ChatType.ExtraChatLinkshell6 => Language.ChatType_ExtraChatLinkshell6,
+            ChatType.ExtraChatLinkshell7 => Language.ChatType_ExtraChatLinkshell7,
+            ChatType.ExtraChatLinkshell8 => Language.ChatType_ExtraChatLinkshell8,
             _ => type.ToString(),
         };
     }

--- a/ChatTwo/Code/InputChannel.cs
+++ b/ChatTwo/Code/InputChannel.cs
@@ -29,4 +29,14 @@ internal enum InputChannel : uint {
     Linkshell6 = 24,
     Linkshell7 = 25,
     Linkshell8 = 26,
+    
+    // Custom channels:
+    ExtraChatLinkshell1 = 1001,
+    ExtraChatLinkshell2 = 1002,
+    ExtraChatLinkshell3 = 1003,
+    ExtraChatLinkshell4 = 1004,
+    ExtraChatLinkshell5 = 1005,
+    ExtraChatLinkshell6 = 1006,
+    ExtraChatLinkshell7 = 1007,
+    ExtraChatLinkshell8 = 1008,
 }

--- a/ChatTwo/Code/InputChannelExt.cs
+++ b/ChatTwo/Code/InputChannelExt.cs
@@ -30,6 +30,14 @@ internal static class InputChannelExt {
         InputChannel.Linkshell6 => ChatType.Linkshell6,
         InputChannel.Linkshell7 => ChatType.Linkshell7,
         InputChannel.Linkshell8 => ChatType.Linkshell8,
+        InputChannel.ExtraChatLinkshell1 => ChatType.ExtraChatLinkshell1,
+        InputChannel.ExtraChatLinkshell2 => ChatType.ExtraChatLinkshell2,
+        InputChannel.ExtraChatLinkshell3 => ChatType.ExtraChatLinkshell3,
+        InputChannel.ExtraChatLinkshell4 => ChatType.ExtraChatLinkshell4,
+        InputChannel.ExtraChatLinkshell5 => ChatType.ExtraChatLinkshell5,
+        InputChannel.ExtraChatLinkshell6 => ChatType.ExtraChatLinkshell6,
+        InputChannel.ExtraChatLinkshell7 => ChatType.ExtraChatLinkshell7,
+        InputChannel.ExtraChatLinkshell8 => ChatType.ExtraChatLinkshell8,
         _ => throw new ArgumentOutOfRangeException(nameof(input), input, null),
     };
 
@@ -50,6 +58,14 @@ internal static class InputChannelExt {
         InputChannel.CrossLinkshell6 => 5,
         InputChannel.CrossLinkshell7 => 6,
         InputChannel.CrossLinkshell8 => 7,
+        InputChannel.ExtraChatLinkshell1 => 0,
+        InputChannel.ExtraChatLinkshell2 => 1,
+        InputChannel.ExtraChatLinkshell3 => 2,
+        InputChannel.ExtraChatLinkshell4 => 3,
+        InputChannel.ExtraChatLinkshell5 => 4,
+        InputChannel.ExtraChatLinkshell6 => 5,
+        InputChannel.ExtraChatLinkshell7 => 6,
+        InputChannel.ExtraChatLinkshell8 => 7,
         _ => uint.MaxValue,
     };
 
@@ -79,6 +95,14 @@ internal static class InputChannelExt {
         InputChannel.Linkshell6 => "/linkshell6",
         InputChannel.Linkshell7 => "/linkshell7",
         InputChannel.Linkshell8 => "/linkshell8",
+        InputChannel.ExtraChatLinkshell1 => "/ecl1",
+        InputChannel.ExtraChatLinkshell2 => "/ecl2",
+        InputChannel.ExtraChatLinkshell3 => "/ecl3",
+        InputChannel.ExtraChatLinkshell4 => "/ecl4",
+        InputChannel.ExtraChatLinkshell5 => "/ecl5",
+        InputChannel.ExtraChatLinkshell6 => "/ecl6",
+        InputChannel.ExtraChatLinkshell7 => "/ecl7",
+        InputChannel.ExtraChatLinkshell8 => "/ecl8",
         _ => "",
     };
 
@@ -148,6 +172,18 @@ internal static class InputChannelExt {
         InputChannel.CrossLinkshell6 => true,
         InputChannel.CrossLinkshell7 => true,
         InputChannel.CrossLinkshell8 => true,
+        _ => false,
+    };
+    
+    internal static bool IsExtraChatLinkshell(this InputChannel channel) => channel switch {
+        InputChannel.ExtraChatLinkshell1 => true,
+        InputChannel.ExtraChatLinkshell2 => true,
+        InputChannel.ExtraChatLinkshell3 => true,
+        InputChannel.ExtraChatLinkshell4 => true,
+        InputChannel.ExtraChatLinkshell5 => true,
+        InputChannel.ExtraChatLinkshell6 => true,
+        InputChannel.ExtraChatLinkshell7 => true,
+        InputChannel.ExtraChatLinkshell8 => true,
         _ => false,
     };
 }

--- a/ChatTwo/GameFunctions/Chat.cs
+++ b/ChatTwo/GameFunctions/Chat.cs
@@ -611,7 +611,12 @@ internal sealed unsafe class Chat : IDisposable {
     }
 
     internal void SetChannel(InputChannel channel, string? tellTarget = null) {
-        if (ChangeChatChannel == null)
+        // ExtraChat linkshells aren't supported in game so we never want to
+        // call the ChangeChatChannel function with them.
+        //
+        // Callers should call ChatLogWindow.SetChannel() which handles
+        // ExtraChat channels
+        if (ChangeChatChannel == null || channel.IsExtraChatLinkshell())
             return;
 
         var target = Utf8String.FromString(tellTarget ?? "");

--- a/ChatTwo/PayloadHandler.cs
+++ b/ChatTwo/PayloadHandler.cs
@@ -592,7 +592,7 @@ public sealed class PayloadHandler {
 
         var inputChannel = chunk.Message?.Code.Type.ToInputChannel();
         if (inputChannel != null && ImGui.Selectable(Language.Context_ReplyInSelectedChatMode)) {
-            LogWindow.Plugin.Functions.Chat.SetChannel(inputChannel.Value);
+            LogWindow.SetChannel(inputChannel.Value);
             LogWindow.Activate = true;
         }
 

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -420,6 +420,78 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [1].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell1 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [2].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell2 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [3].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell3 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [4].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell4 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell4", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [5].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell5 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [6].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell6 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell6", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [7].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell7 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell7", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ExtraChat Linkshell [8].
+        /// </summary>
+        internal static string ChatType_ExtraChatLinkshell8 {
+            get {
+                return ResourceManager.GetString("ChatType_ExtraChatLinkshell8", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Free Company.
         /// </summary>
         internal static string ChatType_FreeCompany {

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -871,4 +871,28 @@
     <data name="Options_TooltipOffset_Desc" xml:space="preserve">
         <value>Use this option if you experience cut-off tooltips.</value>
     </data>
+    <data name="ChatType_ExtraChatLinkshell1" xml:space="preserve">
+        <value>ExtraChat Linkshell [1]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell2" xml:space="preserve">
+        <value>ExtraChat Linkshell [2]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell3" xml:space="preserve">
+        <value>ExtraChat Linkshell [3]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell4" xml:space="preserve">
+        <value>ExtraChat Linkshell [4]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell5" xml:space="preserve">
+        <value>ExtraChat Linkshell [5]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell6" xml:space="preserve">
+        <value>ExtraChat Linkshell [6]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell7" xml:space="preserve">
+        <value>ExtraChat Linkshell [7]</value>
+    </data>
+    <data name="ChatType_ExtraChatLinkshell8" xml:space="preserve">
+        <value>ExtraChat Linkshell [8]</value>
+    </data>
 </root>


### PR DESCRIPTION
Adds ExtraChat Linkshell channels to tab input channel selector. These are only by index, not by channel name due to limitations in the ExtraChat IPC API (tab channel will only show `ECLS [X]` instead of `ECLS [X]: Linkshell Name`).

Because we can't get a map from linkshell number to linkshell name (AFAIK we can only get "ID" to name) from the ExtraChat plugin we show all numbers from 1 through 8 in the selectors. If people don't use the ExtraChat plugin or aren't in any EC linkshells, these options won't appear in the channel selector.

Adds ExtraChat Linkshell channels to the channel selector in the chat log window. As these aren't real channels in-game, these are handled by just sending the corresponding `/eclX` command which causes ExtraChat to set a channel override (which includes the linkshell name). This avoids calling the games `ChangeChatChannel` method with these custom channel types.

https://github.com/Infiziert90/ChatTwo/assets/11241812/f927074e-4984-416e-84cb-fb539fe933f9

Closes #4 

