### PR TITLE
fix: hide command help window when disabled

### DIFF
--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -78,7 +78,7 @@ public sealed class ChatLogWindow : Window, IUiComponent {
         SizeCondition = ImGuiCond.FirstUseEver;
         SizeConstraints = new WindowSizeConstraints
         {
-            MinimumSize = new Vector2(500, 250),
+            MinimumSize = new Vector2(100, 100),
             MaximumSize = new Vector2(float.MaxValue, float.MaxValue)
         };
 
@@ -600,7 +600,7 @@ public sealed class ChatLogWindow : Window, IUiComponent {
 
             var enter = ImGui.IsKeyDown(ImGuiKey.Enter) || ImGui.IsKeyDown(ImGuiKey.KeypadEnter);
             if (enter) {
-                Plugin.CommandHelpWindow.IsOpen = false;
+                Plugin.CommandHelpWindow.UpdateContentAndShow(null);
                 SendChatBox(activeTab);
 
                 if (Plugin.Functions.Chat.UsesTellTempChannel)
@@ -1249,7 +1249,7 @@ public sealed class ChatLogWindow : Window, IUiComponent {
             _activatePos = -1;
         }
 
-        Plugin.CommandHelpWindow.IsOpen = false;
+        Plugin.CommandHelpWindow.UpdateContentAndShow(null);
         var text = MemoryHelper.ReadString((IntPtr) data->Buf, data->BufTextLen);
         if (text.StartsWith('/')) {
             var command = text.Split(' ')[0];
@@ -1258,8 +1258,7 @@ public sealed class ChatLogWindow : Window, IUiComponent {
                                                                                                      || cmd.ShortCommand.RawString == command
                                                                                                      || cmd.ShortAlias.RawString == command);
             if (cmd != null) {
-                Plugin.CommandHelpWindow.UpdateContent(cmd);
-                Plugin.CommandHelpWindow.IsOpen = true;
+                Plugin.CommandHelpWindow.UpdateContentAndShow(cmd);
             }
         }
 

--- a/ChatTwo/Ui/CommandHelpWindow.cs
+++ b/ChatTwo/Ui/CommandHelpWindow.cs
@@ -20,9 +20,19 @@ public class CommandHelpWindow : Window {
                 ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoFocusOnAppearing | ImGuiWindowFlags.AlwaysAutoResize;
     }
 
-    public void UpdateContent(TextCommand command)
+    /// <summary>
+    /// Sets the TextCommand to show and opens the window in the configured
+    /// location. If the provided command is null, the window is closed. If the
+    /// window is already open, it will display the new command. If the user
+    /// has configured the window to be hidden, it will not be shown.
+    /// </summary>
+    public void UpdateContentAndShow(TextCommand? command)
     {
         Command = command;
+        if (command == null) {
+            IsOpen = false;
+            return;
+        }
 
         var width = 350;
         var scaledWidth = width * ImGuiHelpers.GlobalScale;
@@ -36,6 +46,8 @@ public class CommandHelpWindow : Window {
                 break;
             case CommandHelpSide.None:
             default:
+                Command = null;
+                IsOpen = false;
                 return;
         }
 
@@ -45,6 +57,7 @@ public class CommandHelpWindow : Window {
             MinimumSize = new Vector2(width, 0),
             MaximumSize = LogWindow.LastWindowSize with { X = width }
         };
+        IsOpen = true;
     }
 
     public override void Draw()


### PR DESCRIPTION
Makes sure the command help window is hidden when the feature is disabled.

Changes the minimum size of the chat log window to 100x100. Users can pick whatever size they want and lock the size in settings.

Closes #5 