### PR TITLE
fix: censor tell target in Eureka in ScreenshotMode

### DIFF
--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -513,6 +513,28 @@ public sealed class ChatLogWindow : Window, IUiComponent {
                 }
             } else if (Plugin.ExtraChat.ChannelOverride is var (overrideName, _)) {
                 ImGui.TextUnformatted(overrideName);
+            } else if (ScreenshotMode && Plugin.Functions.Chat.Channel is (InputChannel.Tell, _, var tellPlayerName, var tellWorldId)) {
+                if (!string.IsNullOrWhiteSpace(tellPlayerName) && tellWorldId != 0)
+                {
+                    var playerName = HashPlayer(tellPlayerName, tellWorldId);
+                    var world = Plugin.DataManager.GetExcelSheet<World>()
+                        ?.GetRow(tellWorldId)
+                        ?.Name
+                        ?.RawString ?? "???";
+
+                    DrawChunks(new Chunk[] {
+                        new TextChunk(ChunkSource.None, null, "Tell "),
+                        new TextChunk(ChunkSource.None, null, playerName),
+                        new IconChunk(ChunkSource.None, null, BitmapFontIcon.CrossWorld),
+                        new TextChunk(ChunkSource.None, null, world),
+                    });
+                }
+                else
+                {
+                    // We still need to censor the name if we couldn't read
+                    // valid data.
+                    ImGui.TextUnformatted("Tell");
+                }
             } else {
                 DrawChunks(Plugin.Functions.Chat.Channel.name);
             }


### PR DESCRIPTION
Tracks the tell target player name and world ID in `ChangeChannelNameDetour`, and uses this information to censor the tell target in screenshot mode. This allows us to censor the tell target channel name in Eureka/Bozja.

This also resolves a visual glitch caused by #9 related to ScreenshotMode (which happens outside of Eureka/Bozja).

![image](https://github.com/Infiziert90/ChatTwo/assets/11241812/99906913-af8a-4664-b60c-45209b03da74)
