### PR TITLE
fix: avoid warning logs about extrachat

### DIFF
--- a/ChatTwo/Code/ChatTypeExt.cs
+++ b/ChatTwo/Code/ChatTypeExt.cs
@@ -87,6 +87,8 @@ internal static class ChatTypeExt
             ChatType.MessageBook,
             ChatType.Alarm,
         }),
+        // Note: ExtraChat linkshells are handled separately in the tab settings
+        // UI.
     };
 
     internal static string Name(this ChatType type)
@@ -352,6 +354,19 @@ internal static class ChatTypeExt
         ChatType.GmLinkshell7 => true,
         ChatType.GmLinkshell8 => true,
         ChatType.GmNoviceNetwork => true,
+        _ => false,
+    };
+
+    internal static bool IsExtraChatLinkshell(this ChatType type) => type switch
+    {
+        ChatType.ExtraChatLinkshell1 => true,
+        ChatType.ExtraChatLinkshell2 => true,
+        ChatType.ExtraChatLinkshell3 => true,
+        ChatType.ExtraChatLinkshell4 => true,
+        ChatType.ExtraChatLinkshell5 => true,
+        ChatType.ExtraChatLinkshell6 => true,
+        ChatType.ExtraChatLinkshell7 => true,
+        ChatType.ExtraChatLinkshell8 => true,
         _ => false,
     };
 

--- a/ChatTwo/Ui/SettingsTabs/ChatColours.cs
+++ b/ChatTwo/Ui/SettingsTabs/ChatColours.cs
@@ -19,9 +19,13 @@ internal sealed class ChatColours : ISettingsTab {
         #if DEBUG
         var sortable = ChatTypeExt.SortOrder
             .SelectMany(entry => entry.Item2)
-            .Where(type => !type.IsGm())
+            // Users can set colours for ExtraChat linkshells in the ExtraChat
+            // plugin directly.
+            .Where(type => !type.IsGm() && !type.IsExtraChatLinkshell())
             .ToHashSet();
-        var total = Enum.GetValues<ChatType>().Where(type => !type.IsGm()).ToHashSet();
+        var total = Enum.GetValues<ChatType>()
+            .Where(type => !type.IsGm() && !type.IsExtraChatLinkshell())
+            .ToHashSet();
         if (sortable.Count != total.Count) {
             Plugin.Log.Warning($"There are {sortable.Count} sortable channels, but there are {total.Count} total channels.");
             total.ExceptWith(sortable);


### PR DESCRIPTION
Before and after:

![ffxiv_dx11_vw3FUrNzn0](https://github.com/Infiziert90/ChatTwo/assets/11241812/700fcfd4-5402-4dc4-8a79-8c132c3f0255)
