### PR TITLE
feat: add database details section to settings

### DIFF
--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -1635,6 +1635,33 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clear the message history database.
+        /// </summary>
+        internal static string Options_ClearDatabase_Button {
+            get {
+                return ResourceManager.GetString("Options_ClearDatabase_Button", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully cleared the chat database.
+        /// </summary>
+        internal static string Options_ClearDatabase_Success {
+            get {
+                return ResourceManager.GetString("Options_ClearDatabase_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removes all message history. Cannot be restored. Hold Ctrl+Shift to click..
+        /// </summary>
+        internal static string Options_ClearDatabase_Tooltip {
+            get {
+                return ResourceManager.GetString("Options_ClearDatabase_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Replace consecutive duplicate messages with a counter appended to the first instance of the message..
         /// </summary>
         internal static string Options_CollapseDuplicateMessages_Description {
@@ -1685,6 +1712,69 @@ namespace ChatTwo.Resources {
         internal static string Options_Database_Advanced_Warning {
             get {
                 return ResourceManager.GetString("Options_Database_Advanced_Warning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Click to copy database directory path.
+        /// </summary>
+        internal static string Options_Database_Metadata_CopyConfigPath {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_CopyConfigPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copied database directory path to clipboard.
+        /// </summary>
+        internal static string Options_Database_Metadata_CopyConfigPathNotification {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_CopyConfigPathNotification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Database details:.
+        /// </summary>
+        internal static string Options_Database_Metadata_Heading {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_Heading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log size: {0}.
+        /// </summary>
+        internal static string Options_Database_Metadata_LogSize {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_LogSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stored messages: {0:N0}/{1:N0}.
+        /// </summary>
+        internal static string Options_Database_Metadata_MessageCount {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_MessageCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path: {0}.
+        /// </summary>
+        internal static string Options_Database_Metadata_Path {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_Path", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Size: {0}.
+        /// </summary>
+        internal static string Options_Database_Metadata_Size {
+            get {
+                return ResourceManager.GetString("Options_Database_Metadata_Size", resourceCulture);
             }
         }
         

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -952,4 +952,34 @@
     <data name="Options_HideInLoadingScreens_Description" xml:space="preserve">
         <value>Hide {0} during loading screens.</value>
     </data>
+    <data name="Options_ClearDatabase_Button">
+        <value>Clear the message history database</value>
+    </data>
+    <data name="Options_ClearDatabase_Success">
+        <value>Successfully cleared the chat database</value>
+    </data>
+    <data name="Options_ClearDatabase_Tooltip">
+        <value>Removes all message history. Cannot be restored. Hold Ctrl+Shift to click.</value>
+    </data>
+    <data name="Options_Database_Metadata_CopyConfigPath">
+        <value>Click to copy database directory path</value>
+    </data>
+    <data name="Options_Database_Metadata_CopyConfigPathNotification">
+        <value>Copied database directory path to clipboard</value>
+    </data>
+    <data name="Options_Database_Metadata_Heading">
+        <value>Database details:</value>
+    </data>
+    <data name="Options_Database_Metadata_LogSize">
+        <value>Log size: {0}</value>
+    </data>
+    <data name="Options_Database_Metadata_MessageCount">
+        <value>Stored messages: {0:N0}/{1:N0}</value>
+    </data>
+    <data name="Options_Database_Metadata_Path">
+        <value>Path: {0}</value>
+    </data>
+    <data name="Options_Database_Metadata_Size">
+        <value>Size: {0}</value>
+    </data>
 </root>

--- a/ChatTwo/Ui/Settings.cs
+++ b/ChatTwo/Ui/Settings.cs
@@ -35,7 +35,7 @@ public sealed class SettingsWindow : Window, IUiComponent
             new Ui.SettingsTabs.Fonts(Mutable),
             new ChatColours(Mutable, Plugin),
             new Tabs(Plugin, Mutable),
-            new Database(Mutable, Plugin.Store),
+            new Database(Mutable, Plugin),
             new Miscellaneous(Mutable),
             new About(),
         };

--- a/ChatTwo/Util/ImGuiUtil.cs
+++ b/ChatTwo/Util/ImGuiUtil.cs
@@ -234,6 +234,22 @@ internal static class ImGuiUtil {
         return r;
     }
 
+    internal static bool CtrlShiftButton(string label, string tooltip = "")
+    {
+        var io = ImGui.GetIO();
+        var ctrlShiftHeld = io.KeyCtrl && io.KeyShift;
+        if (!ctrlShiftHeld) ImGui.BeginDisabled();
+        var ret = ImGui.Button(label) && ctrlShiftHeld;
+        if (!ctrlShiftHeld) ImGui.EndDisabled();
+        if (!string.IsNullOrEmpty(tooltip) && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled)) {
+            ImGui.BeginTooltip();
+            ImGui.TextUnformatted(tooltip);
+            ImGui.EndTooltip();
+        }
+
+        return ret;
+    }
+
     internal static bool TryToImGui(this VirtualKey key, out ImGuiKey result) {
         result = key switch {
             VirtualKey.NO_KEY => ImGuiKey.None,

--- a/ChatTwo/Util/StringUtil.cs
+++ b/ChatTwo/Util/StringUtil.cs
@@ -10,4 +10,16 @@ internal static class StringUtil {
         bytes[^1] = 0;
         return bytes;
     }
+
+    // Taken from https://stackoverflow.com/a/4975942
+    internal static String BytesToString(long byteCount) {
+        string[] suf = ["B", "KB", "MB", "GB", "TB", "PB", "EB"]; // Longs run out around EB
+        if (byteCount == 0)
+            return "0" + suf[0];
+
+        var bytes = Math.Abs(byteCount);
+        var place = Convert.ToInt32(Math.Floor(Math.Log(bytes, 1024)));
+        var num = Math.Round(bytes / Math.Pow(1024, place), 1);
+        return (Math.Sign(byteCount) * num).ToString("N0") + suf[place];
+    }
 }


### PR DESCRIPTION
Shows path to database (click to copy), database size, database log size, message count.

Also adds a Ctrl+Shift button to wipe the database permanently. This is performed by clearing the Messages collection and then rebuilding the database, which brings it down to around 48KB on my machine (even with many messages).

![ffxiv_dx11_SzMwo60JfI](https://github.com/Infiziert90/ChatTwo/assets/11241812/06b5186d-eea1-4af6-9ab1-4eb2bb40fd4c)
