### PR TITLE
Add option to limit the amount of shown log lines

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -39,6 +39,7 @@ internal class Configuration : IPluginConfiguration
     public bool SortAutoTranslate;
     public bool CollapseDuplicateMessages;
     public bool PlaySounds = true;
+    public int MaxLinesToRender = 10_000;
 
     public bool FontsEnabled = true;
     public ExtraGlyphRanges ExtraGlyphRanges = 0;
@@ -83,6 +84,7 @@ internal class Configuration : IPluginConfiguration
         SortAutoTranslate = other.SortAutoTranslate;
         CollapseDuplicateMessages = other.CollapseDuplicateMessages;
         PlaySounds = other.PlaySounds;
+        MaxLinesToRender = other.MaxLinesToRender;
         FontsEnabled = other.FontsEnabled;
         ExtraGlyphRanges = other.ExtraGlyphRanges;
         FontSize = other.FontSize;

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -2094,6 +2094,24 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Limits the amount of log lines to show in the chat window. This may slightly improve performance..
+        /// </summary>
+        internal static string Options_MaxLinesToShow_Description {
+            get {
+                return ResourceManager.GetString("Options_MaxLinesToShow_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum amount of log lines to display in the chat window.
+        /// </summary>
+        internal static string Options_MaxLinesToShow_Name {
+            get {
+                return ResourceManager.GetString("Options_MaxLinesToShow_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Miscellaneous.
         /// </summary>
         internal static string Options_Miscellaneous_Tab {

--- a/ChatTwo/Resources/Language.nl.resx
+++ b/ChatTwo/Resources/Language.nl.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-    <!-- 
-      Microsoft ResX Schema 
-      
+    <!--
+      Microsoft ResX Schema
+
       Version 2.0
-      
-      The primary goals of this format is to allow a simple XML format 
-      that is mostly human readable. The generation and parsing of the 
-      various data types are done through the TypeConverter classes 
+
+      The primary goals of this format is to allow a simple XML format
+      that is mostly human readable. The generation and parsing of the
+      various data types are done through the TypeConverter classes
       associated with the data types.
-      
+
       Example:
-      
+
       ... ado.net/XML headers & schema ...
       <resheader name="resmimetype">text/microsoft-resx</resheader>
       <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
           <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
           <comment>This is a comment</comment>
       </data>
-                  
-      There are any number of "resheader" rows that contain simple 
+
+      There are any number of "resheader" rows that contain simple
       name/value pairs.
-      
-      Each data row contains a name, and value. The row also contains a 
-      type or mimetype. Type corresponds to a .NET class that support 
-      text/value conversion through the TypeConverter architecture. 
-      Classes that don't support this are serialized and stored with the 
+
+      Each data row contains a name, and value. The row also contains a
+      type or mimetype. Type corresponds to a .NET class that support
+      text/value conversion through the TypeConverter architecture.
+      Classes that don't support this are serialized and stored with the
       mimetype set.
-      
-      The mimetype is used for serialized objects, and tells the 
-      ResXResourceReader how to depersist the object. This is currently not 
+
+      The mimetype is used for serialized objects, and tells the
+      ResXResourceReader how to depersist the object. This is currently not
       extensible. For a given mimetype the value must be set accordingly:
-      
-      Note - application/x-microsoft.net.object.binary.base64 is the format 
-      that the ResXResourceWriter will generate, however the reader can 
+
+      Note - application/x-microsoft.net.object.binary.base64 is the format
+      that the ResXResourceWriter will generate, however the reader can
       read any of the formats listed below.
-      
+
       mimetype: application/x-microsoft.net.object.binary.base64
-      value   : The object must be serialized with 
+      value   : The object must be serialized with
               : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
               : and then encoded with base64 encoding.
-      
+
       mimetype: application/x-microsoft.net.object.soap.base64
-      value   : The object must be serialized with 
+      value   : The object must be serialized with
               : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
               : and then encoded with base64 encoding.
-  
+
       mimetype: application/x-microsoft.net.object.bytearray.base64
-      value   : The object must be serialized into a byte array 
+      value   : The object must be serialized into a byte array
               : using a System.ComponentModel.TypeConverter
               : and then encoded with base64 encoding.
       -->
@@ -840,5 +840,11 @@
     </data>
     <data name="Options_CollapseDuplicateMessages_Description">
         <value>Vervang opeenvolgende dubbele berichten door een teller die is toegevoegd aan het eerste exemplaar van het bericht.</value>
+    </data>
+    <data name="Options_MaxLinesToShow_Name" xml:space="preserve">
+        <value>Maximum aantal regels om te tonen in het chat venster</value>
+    </data>
+    <data name="Options_MaxLinesToShow_Description" xml:space="preserve">
+        <value>Limiteer het maximum aantal regels die worden getoont in het chatvester.</value>
     </data>
 </root>

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -994,4 +994,10 @@
     <data name="Options_PlaySounds_Description" xml:space="preserve">
         <value>Play sounds on interaction.</value>
     </data>
+    <data name="Options_MaxLinesToShow_Name" xml:space="preserve">
+        <value>Maximum amount of log lines to display in the chat window</value>
+    </data>
+    <data name="Options_MaxLinesToShow_Description" xml:space="preserve">
+        <value>Limits the amount of log lines to show in the chat window. This may slightly improve performance.</value>
+    </data>
 </root>

--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -874,7 +874,11 @@ public sealed class ChatLogWindow : Window, IUiComponent
                 var lastTimestamp = string.Empty;
                 int? lastMessageHash = null;
                 var sameCount = 0;
-                for (var i = 0; i < tab.Messages.Count; i++)
+
+                int maxLines = Plugin.Config.MaxLinesToRender;
+                int startLine = tab.Messages.Count > maxLines ? tab.Messages.Count - maxLines : 0;
+
+                for (int i = startLine; i < tab.Messages.Count; i++)
                 {
                     var message = tab.Messages[i];
 

--- a/ChatTwo/Ui/SettingsTabs/Display.cs
+++ b/ChatTwo/Ui/SettingsTabs/Display.cs
@@ -87,6 +87,12 @@ internal sealed class Display : ISettingsTab {
         ImGuiUtil.DragFloatVertical(Language.Options_WindowOpacity_Name, ref Mutable.WindowAlpha, .25f, 0f, 100f, $"{Mutable.WindowAlpha:N2}%%", ImGuiSliderFlags.AlwaysClamp);
         ImGui.Spacing();
 
+
+        if (ImGuiUtil.InputIntVertical(Language.Options_MaxLinesToShow_Name, Language.Options_MaxLinesToShow_Description, ref Mutable.MaxLinesToRender)) {
+            Mutable.MaxLinesToRender = Math.Clamp(Mutable.MaxLinesToRender, 1, 10_000);
+        }
+        ImGui.Spacing();
+
         ImGuiUtil.OptionCheckbox(ref Mutable.CanMove, Language.Options_CanMove_Name);
         ImGui.Spacing();
 

--- a/ChatTwo/Util/ImGuiUtil.cs
+++ b/ChatTwo/Util/ImGuiUtil.cs
@@ -234,6 +234,15 @@ internal static class ImGuiUtil {
         return r;
     }
 
+    internal static bool InputIntVertical(string label, string description, ref int value, int step = 1, int stepFast = 100, ImGuiInputTextFlags flags = ImGuiInputTextFlags.None) {
+        ImGui.TextUnformatted(label);
+        ImGui.SetNextItemWidth(-1);
+        var r = ImGui.InputInt($"##{label}", ref value, step, stepFast, flags);
+        HelpText(description);
+
+        return r;
+    }
+
     internal static bool CtrlShiftButton(string label, string tooltip = "")
     {
         var io = ImGui.GetIO();


### PR DESCRIPTION
Adds an option to limit the amount of lines being rendered in the chat frame.
Default to 10k to keep it similar to the max database size right now.
