### PR TITLE
fix: add Races, Clans and Companion Actions to auto-translate

### DIFF
--- a/ChatTwo/Plugin.cs
+++ b/ChatTwo/Plugin.cs
@@ -120,6 +120,13 @@ public sealed class Plugin : IDalamudPlugin
             Framework.Update += FrameworkUpdate;
             Interface.UiBuilder.Draw += Draw;
             Interface.LanguageChanged += LanguageChanged;
+
+#if !DEBUG
+            // Avoid 300ms hitch when sending first message by preloading the
+            // auto-translate cache. Don't do this in debug because it makes
+            // profiling difficult.
+            AutoTranslate.PreloadCache(DataManager);
+#endif
         }
         catch
         {


### PR DESCRIPTION
The Race, Tribe and BuddyAction sheets were skipped as the default behavior was to include rows from `0..^0` if no range was specified in the Completion sheet. That range would usually include everything, but since the ranges were iterated over as integers there is no "last" index so `^0` equals zero.

Also preloads the AutoTranslate cache on plugin load in a new thread to avoid a hitch when sending the first message. This behavior is disabled in DEBUG builds to make profiling easier.

Pasting `<at:52,4> <at:53,7> <at:58,4>` into dev and current release:
![ffxiv_dx11_WNYm9d45jK](https://github.com/Infiziert90/ChatTwo/assets/11241812/270ba255-3f0b-4748-b644-c4e71d79ec5a)

![image](https://github.com/Infiziert90/ChatTwo/assets/11241812/09122903-ef0e-4ca3-b814-f178b08dc10e)

