### PR TITLE
Handle event items by checking item kind

### DIFF
--- a/ChatTwo/GameFunctions/GameFunctions.cs
+++ b/ChatTwo/GameFunctions/GameFunctions.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
 using Dalamud.Memory;
 using Dalamud.Utility.Signatures;
@@ -151,7 +152,7 @@ internal unsafe class GameFunctions : IDisposable
         return (*flags & (1 << 22)) == 0;
     }
 
-    internal static void OpenItemTooltip(uint id)
+    internal static void OpenItemTooltip(uint id, ItemPayload.ItemKind itemKind)
     {
         var atkStage = AtkStage.GetSingleton();
         var agent = Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.ItemDetail);
@@ -169,7 +170,7 @@ internal unsafe class GameFunctions : IDisposable
         // A54B19: sets some shit
         *(uint*) (agentPtr + 0x20) = 22;
         // A55218: switch goes down to default, which is what we want
-        *(byte*) (agentPtr + 0x118) = 1;
+        *(byte*) (agentPtr + 0x118) = itemKind == ItemPayload.ItemKind.EventItem ? (byte)8 : (byte)1;
         // A54BE0: item id when hovering over item in chat
         *(uint*) (agentPtr + 0x11C) = id;
         // A54BCC: always 0 when hovering over item in chat

--- a/ChatTwo/PayloadHandler.cs
+++ b/ChatTwo/PayloadHandler.cs
@@ -230,11 +230,10 @@ public sealed class PayloadHandler {
                 DoHover(() => HoverStatus(status), hoverSize);
                 break;
             case ItemPayload item:
-                // Event Item do weird things with the client, so we stop vanilla tooltips for now
-                if (LogWindow.Plugin.Config.NativeItemTooltips && item.Kind != ItemPayload.ItemKind.EventItem)
+                if (LogWindow.Plugin.Config.NativeItemTooltips)
                 {
                     if (!_handleTooltips)
-                        GameFunctions.GameFunctions.OpenItemTooltip(item.RawItemId);
+                        GameFunctions.GameFunctions.OpenItemTooltip(item.RawItemId, item.Kind);
 
                     _handleTooltips = true;
                     if (_hoveredItem != item.RawItemId)


### PR DESCRIPTION
I was looking into event item handling and I noticed the default game was setting the `0x118` offset byte to 8 instead of 1 for these items. By doing the same in Chat2, it seems these items are now handled as expected (at least from my testing).