### PR TITLE
Close item tooltip with event to support Dalamud HandleItemOut hook

### DIFF
--- a/ChatTwo/GameFunctions/GameFunctions.cs
+++ b/ChatTwo/GameFunctions/GameFunctions.cs
@@ -203,45 +203,11 @@ internal unsafe class GameFunctions : IDisposable
         var agent = Framework.Instance()->GetUiModule()->GetAgentModule()->GetAgentByInternalId(AgentId.ItemDetail);
         if (agent != null)
         {
-            var atkValues = CloseItemTooltipAtkValues();
-            if (atkValues != null)
-            {
-                try {
-                    var eventObject = stackalloc EventObject[1];
-                    agent->ReceiveEvent(eventObject, atkValues, 1, 0);
-                } finally {
-                    Marshal.FreeHGlobal(new IntPtr(atkValues));
-                }
-            }
-            else
-            {
-                Plugin.Log.Warning("Failed to close tooltip via event");
-                agent->Hide();
-
-                // The game sets them to 0 whenever tooltips aren't hovered anymore
-                var agentPtr = (nint)agent;
-                *(uint*) (agentPtr + 0x138) = 0;
-                *(uint*) (agentPtr + 0x13C) = 0;
-            }
-        }
-    }
-
-    [StructLayout(LayoutKind.Explicit, Size = 64)]
-    private struct EventObject {
-        [FieldOffset(0)] public ulong Unknown0;
-        [FieldOffset(8)] public ulong Unknown8;
-    }
-
-    private static AtkValue* CloseItemTooltipAtkValues()
-    {
-        try {
-            var atkValues = (AtkValue*) Marshal.AllocHGlobal(sizeof(AtkValue));
-            if (atkValues == null) return null;
+            var eventData = stackalloc AtkValue[1];
+            var atkValues = stackalloc AtkValue[1];
             atkValues->Type = ValueType.Int;
             atkValues->Int = -1;
-            return atkValues;
-        } catch {
-            return null;
+            agent->ReceiveEvent(eventData, atkValues, 1, 1);
         }
     }
 


### PR DESCRIPTION
I noticed an issue where item count tooltip lines from Allagan Tools were being added twice to Chat2 linked item tooltips and was able to track down the cause to the way item tooltips are being hidden on mouse out. Currently we just hide the tooltip, but Dalamud has a `HandleItemOut` hook which isn't called when we do this. This hook is used by Allagan Tools to track the last hovered item, and not calling it was causing the issue.

I found that by sending an artificial close event to AgentItemDetail we are able to hide the tooltip without skipping that hook. We also don't need to clean up the struct in that case since the event handler also does that part (though I left it in as a fallback, maybe unnecessarily).