### PR TITLE
chore: use threads for DB reading and writing

### DIFF
--- a/ChatTwo/Code/ChatCode.cs
+++ b/ChatTwo/Code/ChatCode.cs
@@ -92,6 +92,9 @@ internal class ChatCode
     {
         switch (Type)
         {
+            // Error isn't a battle message, but it can be just as spammy if you
+            // use macros with unavailable actions.
+            case ChatType.Error:
             case ChatType.Damage:
             case ChatType.Miss:
             case ChatType.Action:

--- a/ChatTwo/LegacyMessageImporter.cs
+++ b/ChatTwo/LegacyMessageImporter.cs
@@ -166,11 +166,6 @@ internal class LegacyMessageImporter : IAsyncDisposable
         WorkingThread.Start();
     }
 
-    public void Dispose()
-    {
-        _database?.Dispose();
-    }
-
     public async ValueTask DisposeAsync()
     {
         await CancellationToken.CancelAsync();
@@ -339,8 +334,7 @@ internal class LegacyMessageImporter : IAsyncDisposable
         _database.Dispose();
         _database = null;
 
-        if (Plugin != null)
-            Plugin.Framework.Run(() => Plugin.MessageManager.FilterAllTabs(false), token);
+        Plugin?.MessageManager.FilterAllTabsAsync(false);
     }
 
     private static Message BsonDocumentToMessage(BsonDocument doc)

--- a/ChatTwo/Message.cs
+++ b/ChatTwo/Message.cs
@@ -70,8 +70,9 @@ internal class Message {
     internal Dictionary<Guid, float?> Height { get; } = new();
     internal Dictionary<Guid, bool> IsVisible { get; } = new();
 
-    internal Message(ulong receiver, ChatCode code, List<Chunk> sender, List<Chunk> content, SeString senderSource, SeString contentSource) {
+    internal Message(ulong receiver, ulong contentId, ChatCode code, List<Chunk> sender, List<Chunk> content, SeString senderSource, SeString contentSource) {
         Receiver = receiver;
+        ContentId = contentId;
         Date = DateTimeOffset.UtcNow;
         Code = code;
         Sender = sender;

--- a/ChatTwo/Plugin.cs
+++ b/ChatTwo/Plugin.cs
@@ -113,7 +113,7 @@ public sealed class Plugin : IDalamudPlugin
             Commands.Initialise();
 
             if (Interface.Reason is not PluginLoadReason.Boot) {
-                MessageManager.FilterAllTabs(false);
+                MessageManager.FilterAllTabsAsync(false);
             }
 
             Framework.Update += FrameworkUpdate;
@@ -154,7 +154,7 @@ public sealed class Plugin : IDalamudPlugin
 
         ExtraChat?.Dispose();
         Ipc?.Dispose();
-        MessageManager?.Dispose();
+        MessageManager?.DisposeAsync().AsTask().Wait();
         Functions?.Dispose();
         TextureCache?.Dispose();
         Common?.Dispose();

--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -145,13 +145,12 @@ public sealed class ChatLogWindow : Window
 
     private void Logout()
     {
-        foreach (var tab in Plugin.Config.Tabs)
-            tab.Clear();
+        Plugin.MessageManager.ClearAllTabs();
     }
 
     private void Login()
     {
-        Plugin.MessageManager.FilterAllTabs(false);
+        Plugin.MessageManager.FilterAllTabsAsync(false);
     }
 
     private void Activated(ChatActivatedArgs args)
@@ -229,8 +228,7 @@ public sealed class ChatLogWindow : Window
         switch (arguments)
         {
             case "all":
-                foreach (var tab in Plugin.Config.Tabs)
-                    tab.Clear();
+                Plugin.MessageManager.ClearAllTabs();
                 break;
             case "help":
                 Plugin.ChatGui.Print("- /clearlog2: clears the active tab's log");

--- a/ChatTwo/Ui/LegacyMessageImporterWindow.cs
+++ b/ChatTwo/Ui/LegacyMessageImporterWindow.cs
@@ -35,7 +35,7 @@ internal class LegacyMessageImporterWindow : Window
 
     public void Dispose()
     {
-        Importer?.Dispose();
+        Importer?.DisposeAsync().AsTask().Wait();
     }
 
     private void NotificationClicked(INotificationClickArgs args)

--- a/ChatTwo/Ui/Settings.cs
+++ b/ChatTwo/Ui/Settings.cs
@@ -158,7 +158,8 @@ public sealed class SettingsWindow : Window
         // save after 60 frames have passed, which should hopefully not
         // commit any changes that cause a crash
         Plugin.DeferredSaveFrames = 60;
-        Plugin.MessageManager.FilterAllTabs(false);
+        Plugin.MessageManager.ClearAllTabs();
+        Plugin.MessageManager.FilterAllTabsAsync(false);
 
         if (fontChanged || fontSizeChanged)
             Plugin.FontManager.BuildFonts();

--- a/ChatTwo/Ui/SettingsTabs/Database.cs
+++ b/ChatTwo/Ui/SettingsTabs/Database.cs
@@ -133,8 +133,7 @@ internal sealed class Database : ISettingsTab
             {
                 Plugin.Log.Warning("Clearing messages from database");
                 Plugin.MessageManager.Store.ClearMessages();
-                foreach (var tab in Plugin.Config.Tabs)
-                    tab.Clear();
+                Plugin.MessageManager.ClearAllTabs();
 
                 // Refresh on next draw
                 DatabaseLastRefreshTicks = 0;
@@ -156,10 +155,8 @@ internal sealed class Database : ISettingsTab
 
         if (ImGuiUtil.CtrlShiftButton("Reload messages from database", "Ctrl+Shift: MessageManager.FilterAllTabs(false)"))
         {
-            foreach (var tab in Plugin.Config.Tabs)
-                tab.Clear();
-
-            Plugin.MessageManager.FilterAllTabs(false);
+            Plugin.MessageManager.ClearAllTabs();
+            Plugin.MessageManager.FilterAllTabsAsync(false);
         }
 
         if (ImGuiUtil.CtrlShiftButton("Inject 10,000 messages", "Ctrl+Shift: creates 10,000 unique messages (async)"))
@@ -226,9 +223,7 @@ internal sealed class Database : ISettingsTab
         Plugin.Framework.Run(() =>
         {
             stopwatch = Stopwatch.StartNew();
-            foreach (var tab in Plugin.Config.Tabs)
-                tab.Clear();
-
+            Plugin.MessageManager.ClearAllTabs();
             elapsedTicks = stopwatch.ElapsedTicks;
             stopwatch.Stop();
             Plugin.Log.Info($"Cleared {Plugin.Config.Tabs.Count} tabs in {elapsedTicks} ticks ({elapsedTicks / TimeSpan.TicksPerMillisecond}ms)");
@@ -238,6 +233,7 @@ internal sealed class Database : ISettingsTab
         Plugin.Framework.Run(() =>
         {
             stopwatch = Stopwatch.StartNew();
+            // Intentionally synchronous
             Plugin.MessageManager.FilterAllTabs(false);
             elapsedTicks = stopwatch.ElapsedTicks;
             stopwatch.Stop();


### PR DESCRIPTION
Changes almost every `FilterAllTabs()` call to `FilterAllTabsAsync()`, which uses a thread.

Changes incoming message processing to push messages onto a queue which gets processed in a thread in order. Removed accidental double `MessageStore.UpsertMessage()` call.

If "Save battle messages in database" is disabled, "error" messages will no longer be saved. This avoids a bunch of database writes when macros fail.