### PR TITLE
fix: ensure newlines when rendering emotes

### DIFF
--- a/ChatTwo/Message.cs
+++ b/ChatTwo/Message.cs
@@ -135,8 +135,11 @@ internal class Message
     private List<Chunk> CheckMessageContent(List<Chunk> oldChunks)
     {
         var newChunks = new List<Chunk>();
-        void AddChunkWithMessage(Chunk chunk)
+        void AddChunkWithMessage(TextChunk chunk)
         {
+            if (string.IsNullOrEmpty(chunk.Content))
+                return;
+
             chunk.Message = this;
             newChunks.Add(chunk);
         }
@@ -198,7 +201,7 @@ internal class Message
                     AddContentAfterURLCheck(builder.ToString(), text, chunk);
                     builder.Clear();
 
-                    newChunks.Add(new TextChunk(chunk.Source, EmotePayload.ResolveEmote(word), word));
+                    AddChunkWithMessage(new TextChunk(chunk.Source, EmotePayload.ResolveEmote(word), word));
                     builder.Append(' ');
                     continue;
                 }

--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -1005,7 +1005,7 @@ public sealed class ChatLogWindow : Window
                     }
                     else
                     {
-                        DrawChunk(new TextChunk(ChunkSource.None, null, $"[{timestamp}]") { Foreground = 0xFFFFFFFF, });
+                        DrawChunk(new TextChunk(ChunkSource.None, null, $"[{timestamp}] ") { Foreground = 0xFFFFFFFF, });
                         ImGui.SameLine();
                     }
                 }
@@ -1472,13 +1472,17 @@ public sealed class ChatLogWindow : Window
         using var style = ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, Vector2.Zero);
         for (var i = 0; i < chunks.Count; i++)
         {
-            if (chunks[i] is TextChunk text && string.IsNullOrEmpty(text.Content))
-                continue;
-
             DrawChunk(chunks[i], wrap, handler, lineWidth);
 
             if (i < chunks.Count - 1)
                 ImGui.SameLine();
+            else if (chunks[i].Link is EmotePayload) {
+                // Emote payloads seem to not automatically put newlines, which
+                // is an issue when modern mode is disabled.
+                ImGui.SameLine();
+                // Use default ImGui behavior for newlines.
+                ImGui.TextUnformatted("");
+            }
         }
     }
 
@@ -1507,17 +1511,17 @@ public sealed class ChatLogWindow : Window
         if (chunk is not TextChunk text)
             return;
 
-        if (chunk.Link?.Type == (PayloadType)0x53)
+        if (chunk.Link is EmotePayload emotePayload)
         {
             var emoteSize = ImGui.CalcTextSize("W");
             emoteSize = emoteSize with { Y = emoteSize.X } * 1.5f;
 
-            var emotePayload = (EmotePayload) chunk.Link;
             var image = EmoteCache.GetEmote(emotePayload.Code);
             if (image is { IsLoaded: true })
                 image.Draw(emoteSize);
             else
                 ImGui.Dummy(emoteSize);
+            ImGui.SetTooltip(emotePayload.Code);
             return;
         }
 


### PR DESCRIPTION
- Avoids extra `""` text chunks after message parsing if the last chunk was an emote
- Adds an empty string after emote chunks if they're the last item in the chunk list so the ImGui newline code handles everything properly

![ffxiv_dx11_aHtcHQnBnj](https://github.com/Infiziert90/ChatTwo/assets/11241812/a82e7f0b-3986-410c-9e51-ff2a8c7bb892)
