### PR TITLE
chore: move message processing to thread again

### DIFF
--- a/ChatTwo/Util/ExtraPayload.cs
+++ b/ChatTwo/Util/ExtraPayload.cs
@@ -22,88 +22,52 @@ public class ColorPayload
 
         var typeByte = stream.ReadByte();
         var payload = new ColorPayload();
-        if (typeByte == 0xEC)
+        switch (typeByte)
         {
-            payload.Enabled = false;
-            return payload;
-        }
-
-        if (typeByte == 0xE9)
-        {
-            var param = stream.ReadByte();
-            var ok = TryGetGNumDefault((uint) (param - 2), out var value);
-            if (!ok)
+            case 0xEC:
+                payload.Enabled = false;
+                return payload;
+            case 0xE9:
             {
-                Plugin.Log.Error($"Unable to GetGNum for param {param - 2}");
-                return null;
+                var param = stream.ReadByte();
+                var value = (uint) GlobalParametersCache.GetValue(param - 2);
+                payload.Enabled = true;
+                payload.UnshiftedColor = value;
+                payload.Color = ColourUtil.ArgbToRgba(value);
+
+                return payload;
             }
-
-            payload.Enabled = true;
-            payload.UnshiftedColor = value;
-            payload.Color = ColourUtil.ArgbToRgba(value);
-
-            return payload;
-        }
-
-        if (typeByte is >= 0xF0 and <= 0xFE)
-        {
-            // From: https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/Expressions/IntegerExpression.cs#L119-L128
-            uint ShiftAndThrowIfZero(int v, int shift)
+            case >= 0xF0 and <= 0xFE:
             {
-                return v switch
+                // From: https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/Expressions/IntegerExpression.cs#L119-L128
+                uint ShiftAndThrowIfZero(int v, int shift)
                 {
-                    -1 => throw new ArgumentException("Encountered premature end of input (unexpected EOF).", nameof(v)),
-                    0 => throw new ArgumentException("Encountered premature end of input (unexpected null character).", nameof(v)),
-                    _ => (uint)v << shift
-                };
+                    return v switch
+                    {
+                        -1 => throw new ArgumentException("Encountered premature end of input (unexpected EOF).", nameof(v)),
+                        0 => throw new ArgumentException("Encountered premature end of input (unexpected null character).", nameof(v)),
+                        _ => (uint)v << shift
+                    };
+                }
+
+                typeByte += 1;
+                var value = 0u;
+                if ((typeByte & 8) != 0)
+                    value |= ShiftAndThrowIfZero(stream.ReadByte(), 24);
+                else
+                    value |= 0xff000000u;
+
+                if( (typeByte & 4) != 0 ) value |= ShiftAndThrowIfZero( stream.ReadByte(), 16 );
+                if( (typeByte & 2) != 0 ) value |= ShiftAndThrowIfZero( stream.ReadByte(), 8 );
+                if( (typeByte & 1) != 0 ) value |= ShiftAndThrowIfZero( stream.ReadByte(), 0 );
+
+                payload.Enabled = true;
+                payload.Color = ColourUtil.ArgbToRgba(value);
+
+                return payload;
             }
-
-            typeByte += 1;
-            var value = 0u;
-            if ((typeByte & 8) != 0)
-                value |= ShiftAndThrowIfZero(stream.ReadByte(), 24);
-            else
-                value |= 0xff000000u;
-
-            if( (typeByte & 4) != 0 ) value |= ShiftAndThrowIfZero( stream.ReadByte(), 16 );
-            if( (typeByte & 2) != 0 ) value |= ShiftAndThrowIfZero( stream.ReadByte(), 8 );
-            if( (typeByte & 1) != 0 ) value |= ShiftAndThrowIfZero( stream.ReadByte(), 0 );
-
-            payload.Enabled = true;
-            payload.Color = ColourUtil.ArgbToRgba(value);
-
-            return payload;
-        }
-
-        return null;
-    }
-
-    private static unsafe bool TryGetGNumDefault(uint parameterIndex, out uint value)
-    {
-        value = 0u;
-
-        var rtm = RaptureTextModule.Instance();
-        if (rtm is null)
-            return false;
-
-        if (!ThreadSafety.IsMainThread)
-        {
-            Plugin.Log.Error("Global parameters may only be used from the main thread.");
-            return false;
-        }
-
-        ref var gp = ref rtm->TextModule.MacroDecoder.GlobalParameters;
-        if (parameterIndex >= gp.MySize)
-            return false;
-
-        var p = rtm->TextModule.MacroDecoder.GlobalParameters.Get(parameterIndex);
-        switch (p.Type)
-        {
-            case TextParameterType.Integer:
-                value = (uint)p.IntValue;
-                return true;
             default:
-                return false;
+                return null;
         }
     }
 }

--- a/ChatTwo/Util/GlobalParametersCache.cs
+++ b/ChatTwo/Util/GlobalParametersCache.cs
@@ -1,0 +1,46 @@
+﻿using Dalamud.Utility;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using FFXIVClientStructs.FFXIV.Component.Text;
+
+namespace ChatTwo.Util;
+
+public static class GlobalParametersCache
+{
+    private static int[] Cache = [];
+
+    public static int GetValue(int index)
+    {
+        if (index < 0 || index >= Cache.Length)
+            return 0;
+        return Cache[index];
+    }
+
+    /// <summary>
+    /// Refresh the cache of global parameters from RaptureTextModule.
+    /// </summary>
+    /// <remarks>
+    /// This should be called in the main thread when updates are necessary.
+    /// </remarks>
+    public static unsafe void Refresh()
+    {
+        if (!ThreadSafety.IsMainThread)
+            throw new InvalidOperationException("GlobalParametersCache.Refresh must be called on the main thread.");
+
+        var rtm = RaptureTextModule.Instance();
+        if (rtm is null)
+            return;
+
+        ref var gp = ref rtm->TextModule.MacroDecoder.GlobalParameters;
+
+        if (Cache.Length != (int)gp.MySize)
+            Cache = new int[gp.MySize];
+        for (ulong i = 0; i < gp.MySize; i++)
+        {
+            var p = gp.Get(i);
+            if (p.Type == TextParameterType.Integer)
+                Cache[(int)i] = p.IntValue;
+            else
+                Cache[(int)i] = 0;
+        }
+    }
+}


### PR DESCRIPTION
- Add back `PendingMesasage` which contains raw message details
- Adds `GlobalParametersCache` which stores data about chat color codes in a cache so they can be accessed outside of the main thread
    - This gets refreshed every time we receive a message
- Changes the `ChatMessage` handler to always wait a tick before enqueuing messages, even if we don't need to get the Content ID to avoid processing messages out of order