### PR TITLE
fix: various bug fixes

### DIFF
--- a/ChatTwo/Chunk.cs
+++ b/ChatTwo/Chunk.cs
@@ -72,7 +72,9 @@ public class TextChunk : Chunk
 
     internal TextChunk(ChunkSource source, Payload? link, string content) : base(source, link)
     {
-        Content = content;
+        // This has been null in the past, and it broke rendering code.
+        // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+        Content = content ?? "";
     }
 
     // ReSharper disable once UnusedMember.Global // Used by MessagePack
@@ -82,7 +84,9 @@ public class TextChunk : Chunk
         Foreground = foreground;
         Glow = glow;
         Italic = italic;
-        Content = content;
+        // See above.
+        // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
+        Content = content ?? "";
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixes TextChunks with null content from crashing chat log (thanks `@ashekahkol` for reporting)
- Prevents TextChunks fwith null content from being written, they will now be replaced with `""` (thanks `@ashekahkol` for reporting)
- Fixes messages being rendered on the same line as the previous message (thanks `@amper` for reporting)
- Fixes messages being clipped off at the start in modern view (thanks `@nebuchadnezzer2` for reporting)

The last two fixes are solved with a hacky fix, but it seems to work from my testing.