### PR TITLE
fix: avoid loading failed parse messages again

### DIFF
--- a/ChatTwo/Util/ChunkUtil.cs
+++ b/ChatTwo/Util/ChunkUtil.cs
@@ -112,12 +112,8 @@ internal static class ChunkUtil
                         var id = GetInteger(reader);
                         link = new AchievementPayload(id);
                     }
-                    else if (rawPayload.Data.Length > 5 && rawPayload.Data[1] == 0x27 && rawPayload.Data[3] == 0x07)
-                    {
-                        // uri payload
-                        var uri = new Uri(Encoding.UTF8.GetString(rawPayload.Data[4..]));
-                        link = new UriPayload(uri);
-                    }
+                    // NOTE: no URIPayload because it originates solely from
+                    // new Message(). The game doesn't have a URI payload type.
                     else if (Equals(rawPayload, RawPayload.LinkTerminator))
                     {
                         link = null;


### PR DESCRIPTION
- Removes URIPayload parsing in ChunkUtil, as it will never originate from the game
    - This was causing message receive failures
- Adds `Deleted` column to messages table, Deleted messages won't be retrieved when loading history
- If messages fail to parse, they are marked as deleted (but not actually deleted)