### PR TITLE
fix: add last row from some auto-translate categories

### DIFF
--- a/ChatTwo/Util/AutoTranslate.cs
+++ b/ChatTwo/Util/AutoTranslate.cs
@@ -182,7 +182,7 @@ internal static class AutoTranslate
                     // Previously, we were setting `0..^0` which caused these
                     // sheets to be completely skipped due to this bug.
                     // See below.
-                    rows.Add(..Index.FromStart((int)validRows.Max()));
+                    rows.Add(..Index.FromStart((int)validRows.Max() + 1));
 
                 foreach (var range in rows)
                 {


### PR DESCRIPTION
The last row wasn't being included when adding some auto-translate categories, such as Race (so you couldn't pick Viera).

Closes #57 