### PR TITLE
feat: add close button to chat log

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -20,6 +20,7 @@ internal class Configuration : IPluginConfiguration
     public bool HideWhenUiHidden = true;
     public bool HideInLoadingScreens;
     public bool HideInBattle;
+    public bool ShowCloseButton = true;
     public bool NativeItemTooltips = true;
     public bool PrettierTimestamps = true;
     public bool MoreCompactPretty;

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -2832,6 +2832,24 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show a close button next to the settings button. The chat window can be returned by pressing return or slash to focus it..
+        /// </summary>
+        internal static string Options_ShowCloseButton_Description {
+            get {
+                return ResourceManager.GetString("Options_ShowCloseButton_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show close button.
+        /// </summary>
+        internal static string Options_ShowCloseButton_Name {
+            get {
+                return ResourceManager.GetString("Options_ShowCloseButton_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Replaces words with their emote version, currently supports BetterTTV..
         /// </summary>
         internal static string Options_ShowEmotes_Desc {

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -163,6 +163,12 @@
     <data name="Options_ShowNoviceNetwork_Description">
         <value>Show the Novice Network join button next to the settings button if logged in as a mentor.</value>
     </data>
+    <data name="Options_ShowCloseButton_Name" xml:space="preserve">
+        <value>Show close button</value>
+    </data>
+    <data name="Options_ShowCloseButton_Description" xml:space="preserve">
+        <value>Show a close button next to the settings button. The chat window can be returned by pressing return or slash to focus it.</value>
+    </data>
     <data name="Options_FontSize_Name">
         <value>Font size</value>
     </data>

--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -662,7 +662,8 @@ public sealed class ChatLogWindow : Window
 
         var buttonWidth = afterIcon.X - beforeIcon.X;
         var showNovice = Plugin.Config.ShowNoviceNetwork && GameFunctions.GameFunctions.IsMentor();
-        var inputWidth = ImGui.GetContentRegionAvail().X - buttonWidth * (showNovice ? 2 : 1);
+        var buttonsRight = (showNovice ? 1 : 0) + (Plugin.Config.ShowCloseButton ? 1 : 0);
+        var inputWidth = ImGui.GetContentRegionAvail().X - buttonWidth * (1 + buttonsRight);
 
         var inputType = TempChannel?.ToChatType() ?? activeTab?.Channel?.ToChatType() ?? Plugin.Functions.Chat.Channel.Channel.ToChatType();
         var isCommand = Chat.Trim().StartsWith('/');
@@ -774,8 +775,15 @@ public sealed class ChatLogWindow : Window
 
         ImGui.SameLine();
 
-        if (ImGuiUtil.IconButton(FontAwesomeIcon.Cog))
+        if (ImGuiUtil.IconButton(FontAwesomeIcon.Cog, width: (int)buttonWidth))
             Plugin.SettingsWindow.Toggle();
+
+        if (Plugin.Config.ShowCloseButton)
+        {
+            ImGui.SameLine();
+            if (ImGuiUtil.IconButton(FontAwesomeIcon.Times, width: (int)buttonWidth))
+                UserHide();
+        }
 
         if (!showNovice)
             return;

--- a/ChatTwo/Ui/SettingsTabs/ChatLog.cs
+++ b/ChatTwo/Ui/SettingsTabs/ChatLog.cs
@@ -35,6 +35,9 @@ internal sealed class ChatLog : ISettingsTab
             ImGuiUtil.OptionCheckbox(ref Mutable.ShowNoviceNetwork, Language.Options_ShowNoviceNetwork_Name, Language.Options_ShowNoviceNetwork_Description);
             ImGui.Spacing();
 
+            ImGuiUtil.OptionCheckbox(ref Mutable.ShowCloseButton, Language.Options_ShowCloseButton_Name, Language.Options_ShowCloseButton_Description);
+            ImGui.Spacing();
+
             ImGuiUtil.OptionCheckbox(ref Mutable.NativeItemTooltips, Language.Options_NativeItemTooltips_Name, string.Format(Language.Options_NativeItemTooltips_Description, Plugin.PluginName));
             ImGui.Spacing();
 

--- a/ChatTwo/Util/ImGuiUtil.cs
+++ b/ChatTwo/Util/ImGuiUtil.cs
@@ -172,14 +172,20 @@ internal static class ImGuiUtil
         return textEnd;
     }
 
-    internal static bool IconButton(FontAwesomeIcon icon, string? id = null, string? tooltip = null)
+    internal static bool IconButton(FontAwesomeIcon icon, string? id = null, string? tooltip = null, int width = 0)
     {
         var label = icon.ToIconString();
         if (id != null)
             label += $"##{id}";
 
         Plugin.FontManager.FontAwesome.Push();
-        var ret = ImGui.Button(label);
+        var size = new Vector2(0, 0);
+        if (width > 0)
+        {
+            var style = ImGui.GetStyle();
+            size.X = width - 2 * style.CellPadding.X;
+        }
+        var ret = ImGui.Button(label, size);
         Plugin.FontManager.FontAwesome.Pop();
 
         if (tooltip != null && ImGui.IsItemHovered())


### PR DESCRIPTION
Adds a close button beside the settings button in the chat log. Some changes to `ImGuiUtil.IconButton()` were required to ensure the sizes of the buttons matched up.

![ffxiv_dx11_VxjuS6eglE](https://github.com/Infiziert90/ChatTwo/assets/11241812/b8275d15-13dd-4997-83d6-b1935787fb6b)
![ffxiv_dx11_LBw1F7iNt2](https://github.com/Infiziert90/ChatTwo/assets/11241812/e057a38b-8aba-4cce-9e5f-b328697ba6ad)
