### PR TITLE
feat: add autohide after inactivity

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -20,6 +20,8 @@ internal class Configuration : IPluginConfiguration
     public bool HideWhenUiHidden = true;
     public bool HideInLoadingScreens;
     public bool HideInBattle;
+    public bool HideWhenInactive;
+    public int InactivityHideTimeout = 10;
     public bool ShowHideButton = true;
     public bool NativeItemTooltips = true;
     public bool PrettierTimestamps = true;
@@ -78,6 +80,8 @@ internal class Configuration : IPluginConfiguration
         HideWhenUiHidden = other.HideWhenUiHidden;
         HideInLoadingScreens = other.HideInLoadingScreens;
         HideInBattle = other.HideInBattle;
+        HideWhenInactive = other.HideWhenInactive;
+        InactivityHideTimeout = other.InactivityHideTimeout;
         ShowHideButton = other.ShowHideButton;
         NativeItemTooltips = other.NativeItemTooltips;
         PrettierTimestamps = other.PrettierTimestamps;
@@ -169,6 +173,9 @@ internal class Tab
     public uint Unread;
 
     [NonSerialized]
+    public long LastMessageTime;
+
+    [NonSerialized]
     public MessageList Messages = new();
 
     [NonSerialized]
@@ -192,7 +199,10 @@ internal class Tab
     {
         Messages.AddPrune(message, MessageManager.MessageDisplayLimit);
         if (unread)
+        {
             Unread += 1;
+            LastMessageTime = Environment.TickCount64;
+        }
     }
 
     internal void Clear()

--- a/ChatTwo/GameFunctions/Chat.cs
+++ b/ChatTwo/GameFunctions/Chat.cs
@@ -253,9 +253,6 @@ internal sealed unsafe class Chat : IDisposable
             LastRefresh = Environment.TickCount64;
         }
 
-        if (Plugin.ChatLogWindow is { CurrentTab.InputDisabled: true, IsHidden: false })
-            return;
-
         // Vanilla text input has focus
         if (RaptureAtkModule.Instance()->AtkModule.IsTextInputActive())
             return;

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -2418,6 +2418,24 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide the chat after a configurable period of inactivity. The current tab and any tabs with unread indicators enabled are considered for activity..
+        /// </summary>
+        internal static string Options_HideWhenInactive_Description {
+            get {
+                return ResourceManager.GetString("Options_HideWhenInactive_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide when inactive.
+        /// </summary>
+        internal static string Options_HideWhenInactive_Name {
+            get {
+                return ResourceManager.GetString("Options_HideWhenInactive_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide {0} when you are not logged in to a character..
         /// </summary>
         internal static string Options_HideWhenNotLoggedIn_Description {
@@ -2450,6 +2468,24 @@ namespace ChatTwo.Resources {
         internal static string Options_HideWhenUiHidden_Name {
             get {
                 return ResourceManager.GetString("Options_HideWhenUiHidden_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How long to wait (in seconds) before considering the chat log inactive..
+        /// </summary>
+        internal static string Options_InactivityHideTimeout_Description {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideTimeout_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inactivity timeout.
+        /// </summary>
+        internal static string Options_InactivityHideTimeout_Name {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideTimeout_Name", resourceCulture);
             }
         }
         

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -406,6 +406,18 @@
     <data name="Options_HideWhenUiHidden_Description">
         <value>Hide {0} when the game UI is hidden.</value>
     </data>
+    <data name="Options_HideWhenInactive_Name">
+        <value>Hide when inactive</value>
+    </data>
+    <data name="Options_HideWhenInactive_Description">
+        <value>Hide the chat after a configurable period of inactivity. The current tab and any tabs with unread indicators enabled are considered for activity.</value>
+    </data>
+    <data name="Options_InactivityHideTimeout_Name">
+        <value>Inactivity timeout</value>
+    </data>
+    <data name="Options_InactivityHideTimeout_Description">
+        <value>How long to wait (in seconds) before considering the chat log inactive.</value>
+    </data>
     <data name="Options_KeybindMode_Name">
         <value>Keybind mode</value>
     </data>

--- a/ChatTwo/Ui/SettingsTabs/Display.cs
+++ b/ChatTwo/Ui/SettingsTabs/Display.cs
@@ -1,7 +1,5 @@
 using ChatTwo.Resources;
 using ChatTwo.Util;
-using Dalamud.Interface.Style;
-using Dalamud.Interface.Utility.Raii;
 using ImGuiNET;
 
 namespace ChatTwo.Ui.SettingsTabs;
@@ -38,6 +36,19 @@ internal sealed class Display : ISettingsTab
 
         ImGuiUtil.OptionCheckbox(ref Mutable.HideInBattle, Language.Options_HideInBattle_Name, Language.Options_HideInBattle_Description);
         ImGui.Spacing();
+
+        ImGuiUtil.OptionCheckbox(ref Mutable.HideWhenInactive, Language.Options_HideWhenInactive_Name, Language.Options_HideWhenInactive_Description);
+        ImGui.Spacing();
+
+        if (Mutable.HideWhenInactive)
+        {
+            ImGuiUtil.InputIntVertical(Language.Options_InactivityHideTimeout_Name,
+                Language.Options_InactivityHideTimeout_Description, ref Mutable.InactivityHideTimeout, 1, 10);
+            // Enforce a minimum of 2 seconds to avoid people soft locking
+            // themselves.
+            Mutable.InactivityHideTimeout = Math.Max(2, Mutable.InactivityHideTimeout);
+            ImGui.Spacing();
+        }
 
         ImGuiUtil.OptionCheckbox(ref Mutable.PrettierTimestamps, Language.Options_PrettierTimestamps_Name, Language.Options_PrettierTimestamps_Description);
 


### PR DESCRIPTION
After not receiving a message for X seconds (configurable) in the current tab or any tab with unread mode enabled, the chat will be hidden. Focus can be returned with return or slash as usual.

Having input focus or hovering the mouse over the chat window "bumps" it every frame.

Also fixes a bug that prevented focus from being restored to tabs with input disabled. The chat window will now be correctly brought back but the activated event won't be fully processed.

Thanks @aurieh

https://github.com/Infiziert90/ChatTwo/assets/11241812/5a2b4f8a-99e6-4a67-8ae8-b154b7cab9a6

Relates to #80