### PR TITLE
Account for Dalamud's maximum CellPadding in Auto-Scrolling

### DIFF
--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -920,7 +920,7 @@ public sealed class ChatLogWindow : Window
             using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, oldItemSpacing))
             using (ImRaii.PushStyle(ImGuiStyleVar.CellPadding, oldCellPadding))
             {
-                if (switchedTab || ImGui.GetScrollY() >= ImGui.GetScrollMaxY())
+                if (switchedTab || ImGui.GetScrollY() >= ImGui.GetScrollMaxY()-16)
                     ImGui.SetScrollHereY(1f);
 
                 handler.Draw();


### PR DESCRIPTION
Account for Dalamud's maximum `CellPadding` very simplistically as `ImGui.GetScrollMaxY()` apparently does not account for this variable but `ImGui.GetScrollY()` seems to, and these two are compared to Auto-Scroll.
Because of this apparent discrepancy auto-scrolling does not work on `CellPadding` values greater than `4` in custom Dalamud Styles.

`16` because `4` is the default Dalamud CellPadding (which works), and `20` is the max.

Fixes #85.