### PR TITLE
feat: autohide improvements

### DIFF
--- a/ChatTwo/GameFunctions/KeybindManager.cs
+++ b/ChatTwo/GameFunctions/KeybindManager.cs
@@ -10,8 +10,6 @@ using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuiNET;
 using ModifierFlag = ChatTwo.GameFunctions.Types.ModifierFlag;
 
-using ModifierFlag = ChatTwo.GameFunctions.Types.ModifierFlag;
-
 namespace ChatTwo.GameFunctions;
 
 internal enum KeyboardSource {
@@ -95,8 +93,8 @@ internal unsafe class KeybindManager : IDisposable {
 
     // List of keys that can be used as a part of keybinds while the chat is
     // focused WITHOUT modifiers. All other keys can only be used if their
-    // configured keybind contains modifiers. This allows for using e.g. F11 to
-    // change chat channel while typing.
+    // configured keybind contains modifiers (except only SHIFT). This allows
+    // for using e.g. F11 to change chat channel while typing.
     private static readonly IReadOnlyCollection<VirtualKey> ModifierlessChatKeys = new[]
     {
         // VirtualKey.NO_KEY,

--- a/ChatTwo/Message.cs
+++ b/ChatTwo/Message.cs
@@ -124,6 +124,17 @@ internal partial class Message
         return new Message(0, 0, code, [], content, new SeString(), new SeString());
     }
 
+    internal bool Matches(Dictionary<ChatType, ChatSource> channels, bool allExtraChatChannels, HashSet<Guid> extraChatChannels)
+    {
+        if (ExtraChatChannel != Guid.Empty)
+            return allExtraChatChannels || extraChatChannels.Contains(ExtraChatChannel);
+
+        return Code.Type.IsGm()
+               || channels.TryGetValue(Code.Type, out var sources)
+               && (Code.Source is 0 or (ChatSource) 1
+                   || sources.HasFlag(Code.Source));
+    }
+
     private int GenerateHash()
     {
         return SortCode.GetHashCode()

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -2481,7 +2481,7 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hide the chat after a configurable period of inactivity. The current tab and any tabs with unread indicators enabled are considered for activity..
+        ///   Looks up a localized string similar to Hide the chat after a configurable period of inactivity. The current tab and any other tabs with the setting enabled are considered for activity..
         /// </summary>
         internal static string Options_HideWhenInactive_Description {
             get {
@@ -2531,6 +2531,69 @@ namespace ChatTwo.Resources {
         internal static string Options_HideWhenUiHidden_Name {
             get {
                 return ResourceManager.GetString("Options_HideWhenUiHidden_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When disabled, the chat log will stay active during battle..
+        /// </summary>
+        internal static string Options_InactivityHideActiveDuringBattle_Description {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideActiveDuringBattle_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable inactivity hide during battle.
+        /// </summary>
+        internal static string Options_InactivityHideActiveDuringBattle_Name {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideActiveDuringBattle_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select All.
+        /// </summary>
+        internal static string Options_InactivityHideChannels_All_Label {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideChannels_All_Label", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hold Ctrl+Shift to click..
+        /// </summary>
+        internal static string Options_InactivityHideChannels_Button_Tooltip {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideChannels_Button_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Which chat channels should be considered for activity. Other channels will not restore the chat regardless of which tab they occur in..
+        /// </summary>
+        internal static string Options_InactivityHideChannels_Description {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideChannels_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Chat channels considered for activity.
+        /// </summary>
+        internal static string Options_InactivityHideChannels_Name {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideChannels_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unselect All.
+        /// </summary>
+        internal static string Options_InactivityHideChannels_None_Label {
+            get {
+                return ResourceManager.GetString("Options_InactivityHideChannels_None_Label", resourceCulture);
             }
         }
         
@@ -3134,6 +3197,15 @@ namespace ChatTwo.Resources {
         internal static string Options_Tabs_ExtraChatChannels {
             get {
                 return ResourceManager.GetString("Options_Tabs_ExtraChatChannels", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unhide the chat window on activity.
+        /// </summary>
+        internal static string Options_Tabs_InactivityBehaviour {
+            get {
+                return ResourceManager.GetString("Options_Tabs_InactivityBehaviour", resourceCulture);
             }
         }
         

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -220,6 +220,9 @@
     <data name="Options_Tabs_UnreadMode">
         <value>Unread mode</value>
     </data>
+    <data name="Options_Tabs_InactivityBehaviour">
+        <value>Unhide the chat window on activity</value>
+    </data>
     <data name="Options_Tabs_NoInputChannel">
         <value>&lt;None&gt;</value>
     </data>
@@ -410,13 +413,34 @@
         <value>Hide when inactive</value>
     </data>
     <data name="Options_HideWhenInactive_Description">
-        <value>Hide the chat after a configurable period of inactivity. The current tab and any tabs with unread indicators enabled are considered for activity.</value>
+        <value>Hide the chat after a configurable period of inactivity. The current tab and any other tabs with the setting enabled are considered for activity.</value>
     </data>
     <data name="Options_InactivityHideTimeout_Name">
         <value>Inactivity timeout</value>
     </data>
     <data name="Options_InactivityHideTimeout_Description">
         <value>How long to wait (in seconds) before considering the chat log inactive.</value>
+    </data>
+    <data name="Options_InactivityHideActiveDuringBattle_Name" xml:space="preserve">
+        <value>Enable inactivity hide during battle</value>
+    </data>
+    <data name="Options_InactivityHideActiveDuringBattle_Description" xml:space="preserve">
+        <value>When disabled, the chat log will stay active during battle.</value>
+    </data>
+    <data name="Options_InactivityHideChannels_Name">
+        <value>Chat channels considered for activity</value>
+    </data>
+    <data name="Options_InactivityHideChannels_Description">
+        <value>Which chat channels should be considered for activity. Other channels will not restore the chat regardless of which tab they occur in.</value>
+    </data>
+    <data name="Options_InactivityHideChannels_All_Label">
+        <value>Select All</value>
+    </data>
+    <data name="Options_InactivityHideChannels_None_Label">
+        <value>Unselect All</value>
+    </data>
+    <data name="Options_InactivityHideChannels_Button_Tooltip">
+        <value>Hold Ctrl+Shift to click.</value>
     </data>
     <data name="Options_KeybindMode_Name">
         <value>Keybind mode</value>

--- a/ChatTwo/Util/TabsUtil.cs
+++ b/ChatTwo/Util/TabsUtil.cs
@@ -4,6 +4,14 @@ using ChatTwo.Resources;
 namespace ChatTwo.Util;
 
 internal static class TabsUtil {
+    internal static Dictionary<ChatType, ChatSource> AllChannels()
+    {
+        var channels = new Dictionary<ChatType, ChatSource>();
+        foreach (var chatType in Enum.GetValues<ChatType>())
+            channels[chatType] = ChatSourceExt.All;
+        return channels;
+    }
+
     internal static Tab VanillaGeneral => new() {
         Name = Language.Tabs_Presets_General,
         ChatCodes = new Dictionary<ChatType, ChatSource> {


### PR DESCRIPTION
- Adds new setting "Enable inactivity hide during battle" (default: true) which determines whether autohide should apply during battle (thanks @aurieh)
- Adds new setting "Chat channels considered for activity" which allows customizing which channels incoming messages must match to "bump" the inactivity timer
- Adds new per-tab setting "Unhide the chat window on activity" to configure whether it will be considered for "bumping" the inactivity timer when receiving messages that match the new channel filter. Note that the foreground tab is currently always considered.
- Extends autohide code to apply to poped-out tabs as well. Each popout window has its own inactivity timer, but focusing the main window will restore all popped out windows.

