### PR TITLE
fix: avoid switching to non-existent linkshell idx

### DIFF
--- a/ChatTwo/GameFunctions/KeybindManager.cs
+++ b/ChatTwo/GameFunctions/KeybindManager.cs
@@ -9,6 +9,7 @@ using Dalamud.Utility.Signatures;
 using FFXIVClientStructs.FFXIV.Client.System.String;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using ImGuiNET;
+using ModifierFlag = ChatTwo.GameFunctions.Types.ModifierFlag;
 
 namespace ChatTwo.GameFunctions;
 


### PR DESCRIPTION
Prevents switching channels to a non-existent linkshell index (for both regular linkshells and cross-world linkshells). ExtraChat linkshells are already validated separately.

Prevents ChatLogWindow Draw failures from causing ChatTwo to grab input focus each frame if the exception occurs during an Activate event.