### PR TITLE
Added tab support to auto completion box

### DIFF
--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -1503,6 +1503,19 @@ public sealed class ChatLogWindow : Window
 
                 AutoCompleteShouldScroll = true;
                 return 1;
+
+            default:
+                if(ImGui.IsKeyPressed(ImGuiKey.Tab))
+                {
+                    if (AutoCompleteSelection == AutoCompleteList.Count - 1)
+                        AutoCompleteSelection = 0;
+                    else
+                        AutoCompleteSelection++;
+
+                    AutoCompleteShouldScroll = true;
+                    return 1;
+                }
+                break;
         }
 
         return 0;


### PR DESCRIPTION
Heyo,

I added a functionallity to allow the user to cycle through auto complete options using the tab key in the way the base game does. Apologies for the hacky solution, this was due to the callback not recognizing the tab input via the `data->EventKey`. I imagine this is probably doable using the `ImGuiInputTextFlags.AllowTabInput` flag and culling the additional tab input from the buffer but im a bit out of my depth when it comes to C# let alone unsafe code in the language. 

I understand this isn't an ideal solution so please let me know if you have any concerns 😄 

Cheers 