### PR TITLE
Update AutoTranslate for API 11

### DIFF
--- a/ChatTwo/GameFunctions/Chat.cs
+++ b/ChatTwo/GameFunctions/Chat.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using ChatTwo.Code;
 using ChatTwo.GameFunctions.Types;
 using ChatTwo.Resources;
@@ -467,12 +467,12 @@ internal sealed unsafe class Chat : IDisposable
 
     internal void SendTellUsingCommandInner(byte[] message)
     {
-        var mes = new Utf8String(message);
+        var mes = Utf8String.FromSequence(message);
 
-        RaptureShellModule.Instance()->ExecuteCommandInner(&mes, UIModule.Instance());
+        RaptureShellModule.Instance()->ExecuteCommandInner(mes, UIModule.Instance());
         RaptureAtkModule.Instance()->ClearFocus(); // Clear the focus of vanilla chat that was still active
 
-        mes.Dtor(true);
+        mes->Dtor(true);
     }
 
     internal void SendTell(TellReason reason, ulong contentId, string name, ushort homeWorld, byte[] message, string rawText)

--- a/ChatTwo/GameFunctions/Chat.cs
+++ b/ChatTwo/GameFunctions/Chat.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using ChatTwo.Code;
 using ChatTwo.GameFunctions.Types;
 using ChatTwo.Resources;
@@ -455,7 +455,7 @@ internal sealed unsafe class Chat : IDisposable
     internal TellHistoryInfo? GetTellHistoryInfo(int index)
     {
         var acquaintance = AcquaintanceModule.Instance()->GetTellHistory(index);
-        if (acquaintance->ContentId == 0)
+        if (acquaintance == null || acquaintance->ContentId == 0)
             return null;
 
         var name = new ReadOnlySeStringSpan(acquaintance->Name.AsSpan()).ExtractText();


### PR DESCRIPTION
`WorkingRawRow` shouldn't be needed, but using raw row directly like https://github.com/goatcorp/dalamud-docs/blob/main/docs/versions/v11/lumina.md#reading-columns says doesn't work

For some reason the `LookupTable` field now contains some values as macros instead of just string, converting that back is kinda ugly like that, but it works.
The unexpected macro thing is just to ensure there will be an error in the log if they start using other macros in that field

Also fixes 2 minor unrelated issues I found during testing, when I did the whole api 11 update for myself.