### PR TITLE
Hash message links so messages with different links aren't considered the same for deduplication

### DIFF
--- a/ChatTwo/Message.cs
+++ b/ChatTwo/Message.cs
@@ -140,7 +140,10 @@ internal partial class Message
         return SortCode.GetHashCode()
                ^ ExtraChatChannel.GetHashCode()
                ^ string.Join("", Sender.Select(c => c.StringValue())).GetHashCode()
-               ^ string.Join("", Content.Select(c => c.StringValue())).GetHashCode();
+               ^ string.Join("", Content.Select(c => c.StringValue())).GetHashCode()
+               // Hash the link too for something like DeathRecap where the message is the same
+               // but the link is different
+               ^ string.Join("", Content.Select(c => c.Link?.GetHashCode())).GetHashCode();
     }
 
     private static Guid ExtractExtraChatChannel(SeString contentSource)


### PR DESCRIPTION
Plugins like Deathrecap post a message to the chat linking to a specific point in time. Since the deduplication only shows the first message this leads to the link opening an older death when clicked.

With this change message that link to different things are considered as seperate messages and don't get deduplicated.
Before:
![1745885410_2b76394263](https://github.com/user-attachments/assets/509c01ad-85d8-44c5-bb2f-b70cff1ab513)

After:
![1745885375_6c060eb20b](https://github.com/user-attachments/assets/f537ec63-7f25-4d70-b5ce-dbeefe9202d9)

If it should be a toggle instead of being enabled by default I could look into adding that.
I'm also not super familiar with C# so if theres a better way to handle this, feel free to tell me :)