### PR TITLE
Keep the aspect ratio of (de)buff icons intact

### DIFF
--- a/ChatTwo/PayloadHandler.cs
+++ b/ChatTwo/PayloadHandler.cs
@@ -340,7 +340,13 @@ public sealed class PayloadHandler
     private static void InlineIcon(IDalamudTextureWrap icon)
     {
         var cursor = ImGui.GetCursorPos();
-        var size = ImGuiHelpers.ScaledVector2(32, 32);
+        const int maxIconSize = 32;
+        // Keep the icons aspect ratio while also shrinking it down so its at most 32px wide/tall
+        var iconRatio = icon.Size.X / icon.Size.Y;
+        var x = Math.Min(maxIconSize, (int) (maxIconSize * iconRatio));
+        var y = Math.Min(maxIconSize, (int) (maxIconSize / iconRatio));
+        var size = ImGuiHelpers.ScaledVector2(x, y);
+
         ImGui.Image(icon.Handle, size);
         ImGui.SameLine();
         ImGui.SetCursorPos(cursor + new Vector2(size.X + 4, size.Y - ImGui.GetTextLineHeightWithSpacing()));


### PR DESCRIPTION
Prevents the debuff/buff icons from being squished when displayed in Popups and Menus.
Before:
<img width="171" height="75" alt="before" src="https://github.com/user-attachments/assets/a7c88498-6007-441a-ae92-1505a50b3bb9" />
After:
<img width="171" height="75" alt="after" src="https://github.com/user-attachments/assets/987fe95b-b408-45af-9562-b2e0621bcb98" />
