### PR TITLE
Add option to hide when the NG+ menu is open

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -44,6 +44,7 @@ internal class Configuration : IPluginConfiguration
     public bool HideWhenUiHidden = true;
     public bool HideInLoadingScreens;
     public bool HideInBattle;
+    public bool HideInNewGamePlusMenu;
     public bool HideWhenInactive;
     public int InactivityHideTimeout = 10;
     public bool InactivityHideActiveDuringBattle = true;
@@ -135,6 +136,7 @@ internal class Configuration : IPluginConfiguration
         HideWhenUiHidden = other.HideWhenUiHidden;
         HideInLoadingScreens = other.HideInLoadingScreens;
         HideInBattle = other.HideInBattle;
+        HideInNewGamePlusMenu = other.HideInNewGamePlusMenu;
         HideWhenInactive = other.HideWhenInactive;
         InactivityHideTimeout = other.InactivityHideTimeout;
         InactivityHideActiveDuringBattle = other.InactivityHideActiveDuringBattle;
@@ -248,6 +250,7 @@ internal class Tab
     public bool HideWhenUiHidden = true;
     public bool HideInLoadingScreens;
     public bool HideInBattle;
+    public bool HideInNewGamePlusMenu;
     public bool HideWhenInactive;
 
     [NonSerialized] public uint Unread;
@@ -301,6 +304,7 @@ internal class Tab
             HideWhenUiHidden = HideWhenUiHidden,
             HideInLoadingScreens = HideInLoadingScreens,
             HideInBattle = HideInBattle,
+            HideInNewGamePlusMenu = HideInNewGamePlusMenu,
             HideWhenInactive = HideWhenInactive,
         };
     }

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -2497,6 +2497,24 @@ namespace ChatTwo.Resources {
                 return ResourceManager.GetString("Options_HideInBattle_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hide Chat 2 when the New Game+ menu is open.
+        /// </summary>
+        internal static string Options_HideInNewGamePlusMenu_Description {
+            get {
+                return ResourceManager.GetString("Options_HideInNewGamePlusMenu_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hide when New Game+ is open.
+        /// </summary>
+        internal static string Options_HideInNewGamePlusMenu_Name {
+            get {
+                return ResourceManager.GetString("Options_HideInNewGamePlusMenu_Name", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Hide {0} during loading screens..

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -1183,6 +1183,12 @@
     <data name="Options_HideInBattle_Description" xml:space="preserve">
         <value>Hide the chat during battles.</value>
     </data>
+    <data name="Options_HideInNewGamePlusMenu_Name" xml:space="preserve">
+        <value>Hide when New Game+ is open.</value>
+    </data>
+    <data name="Options_HideInNewGamePlusMenu_Description" xml:space="preserve">
+        <value>Hide Chat 2 when the New Game+ menu is open.</value>
+    </data>
     <data name="Options_Emote_EmoteStats" xml:space="preserve">
         <value>Emote Stats</value>
     </data>

--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -387,7 +387,8 @@ public sealed class ChatLogWindow : Window
         Cutscene,
         CutsceneOverride,
         User,
-        Battle
+        Battle,
+        NewGamePlus,
     }
 
     private HideState CurrentHideState = HideState.None;
@@ -410,6 +411,13 @@ public sealed class ChatLogWindow : Window
                 CurrentHideState = HideState.Cutscene;
         }
 
+        var newGamePlusOpen = GameFunctions.GameFunctions.IsAddonInteractable("QuestRedo");
+        if (Plugin.Config.HideInNewGamePlusMenu && CurrentHideState == HideState.None && newGamePlusOpen)
+            CurrentHideState = HideState.NewGamePlus;
+
+        if (CurrentHideState is HideState.NewGamePlus && !newGamePlusOpen)
+            CurrentHideState = HideState.None;
+
         // if the chat is hidden because of a cutscene and no longer in a cutscene, set the hide state to none
         if (CurrentHideState is HideState.Cutscene or HideState.CutsceneOverride && !Plugin.CutsceneActive && !Plugin.GposeActive)
             CurrentHideState = HideState.None;
@@ -422,7 +430,7 @@ public sealed class ChatLogWindow : Window
         if (CurrentHideState == HideState.User && Activate)
             CurrentHideState = HideState.None;
 
-        if (CurrentHideState is HideState.Cutscene or HideState.User or HideState.Battle || (Plugin.Config.HideWhenNotLoggedIn && !Plugin.ClientState.IsLoggedIn))
+        if (CurrentHideState is HideState.Cutscene or HideState.User or HideState.Battle or HideState.NewGamePlus || (Plugin.Config.HideWhenNotLoggedIn && !Plugin.ClientState.IsLoggedIn))
         {
             IsHidden = true;
             return;

--- a/ChatTwo/Ui/Popout.cs
+++ b/ChatTwo/Ui/Popout.cs
@@ -115,7 +115,8 @@ internal class Popout : Window
         Cutscene,
         CutsceneOverride,
         User,
-        Battle
+        Battle,
+        NewGamePlus,
     }
 
     private HideState CurrentHideState = HideState.None;
@@ -137,6 +138,14 @@ internal class Popout : Window
                 CurrentHideState = HideState.Cutscene;
         }
 
+        var newGamePlusOpen = GameFunctions.GameFunctions.IsAddonInteractable("QuestRedo");
+        if (Tab.HideInNewGamePlusMenu && CurrentHideState == HideState.None && newGamePlusOpen)
+            CurrentHideState = HideState.NewGamePlus;
+
+        if (CurrentHideState is HideState.NewGamePlus && !newGamePlusOpen)
+            CurrentHideState = HideState.None;
+
+
         // if the chat is hidden because of a cutscene and no longer in a cutscene, set the hide state to none
         if (CurrentHideState is HideState.Cutscene or HideState.CutsceneOverride && !Plugin.CutsceneActive && !Plugin.GposeActive)
             CurrentHideState = HideState.None;
@@ -149,6 +158,6 @@ internal class Popout : Window
         if (CurrentHideState == HideState.User && ChatLogWindow.Activate)
             CurrentHideState = HideState.None;
 
-        return CurrentHideState is HideState.Cutscene or HideState.User or HideState.Battle || (Tab.HideWhenNotLoggedIn && !Plugin.ClientState.IsLoggedIn);
+        return CurrentHideState is HideState.Cutscene or HideState.User or HideState.Battle or HideState.NewGamePlus || (Tab.HideWhenNotLoggedIn && !Plugin.ClientState.IsLoggedIn);
     }
 }

--- a/ChatTwo/Ui/SettingsTabs/Display.cs
+++ b/ChatTwo/Ui/SettingsTabs/Display.cs
@@ -39,6 +39,9 @@ internal sealed class Display : ISettingsTab
         ImGuiUtil.OptionCheckbox(ref Mutable.HideInBattle, Language.Options_HideInBattle_Name, Language.Options_HideInBattle_Description);
         ImGui.Spacing();
 
+        ImGuiUtil.OptionCheckbox(ref Mutable.HideInNewGamePlusMenu, Language.Options_HideInNewGamePlusMenu_Name, Language.Options_HideInNewGamePlusMenu_Description);
+        ImGui.Spacing();
+
         ImGui.Separator();
         ImGui.Spacing();
 

--- a/ChatTwo/Ui/SettingsTabs/Tabs.cs
+++ b/ChatTwo/Ui/SettingsTabs/Tabs.cs
@@ -111,6 +111,9 @@ internal sealed class Tabs : ISettingsTab
 
                     ImGuiUtil.OptionCheckbox(ref tab.HideInBattle, Language.Options_HideInBattle_Name);
                     ImGui.Spacing();
+
+                    ImGuiUtil.OptionCheckbox(ref tab.HideInNewGamePlusMenu, Language.Options_HideInNewGamePlusMenu_Name);
+                    ImGui.Spacing();
                 }
 
                 ImGuiUtil.OptionCheckbox(ref tab.CanMove, Language.Popout_CanMove_Name);


### PR DESCRIPTION
Adds option to hide the Chat windows when the NG+ menu is opened which fixes #147 

I didn't add an option to force open the window like you can in Cutscenes because that felt a bit unnecessary since the User can just close the NG+ menu.