### PR TITLE
Add typing state IPC integration for enhanced Chat2 input handling

### DIFF
--- a/ChatTwo/Ipc/TypingIpc.cs
+++ b/ChatTwo/Ipc/TypingIpc.cs
@@ -1,0 +1,65 @@
+using ChatTwo.Code;
+using Dalamud.Plugin.Ipc;
+
+namespace ChatTwo.Ipc;
+
+using ChatInputState = (bool InputVisible, bool InputFocused, bool HasText, bool IsTyping, int TextLength, ChatType ChannelType);
+
+internal sealed class TypingIpc : IDisposable
+{
+    private Plugin Plugin { get; }
+
+    private ICallGateProvider<ChatInputState> StateQueryGate { get; }
+    private ICallGateProvider<ChatInputState, object?> StateChangedGate { get; }
+
+    private ChatInputState LastState;
+    private bool HasState;
+
+    internal TypingIpc(Plugin plugin)
+    {
+        Plugin = plugin;
+
+        StateQueryGate = Plugin.Interface.GetIpcProvider<ChatInputState>("ChatTwo.GetChatInputState");
+        StateChangedGate = Plugin.Interface.GetIpcProvider<ChatInputState, object?>("ChatTwo.ChatInputStateChanged");
+
+        StateQueryGate.RegisterFunc(GetState);
+    }
+
+    private ChatInputState BuildState()
+    {
+        var log = Plugin.ChatLogWindow;
+        var chat = log.Chat ?? string.Empty;
+        var hasText = !string.IsNullOrWhiteSpace(chat);
+        var usedChannel = Plugin.CurrentTab?.CurrentChannel;
+        var inputChannel = usedChannel is not null
+            ? (usedChannel.UseTempChannel ? usedChannel.TempChannel : usedChannel.Channel)
+            : InputChannel.Invalid;
+        var channelType = inputChannel.ToChatType();
+
+        return (InputVisible: !log.IsHidden,
+            InputFocused: log.InputFocused,
+            HasText: hasText,
+            IsTyping: log.InputFocused && hasText,
+            TextLength: chat.Length,
+            ChannelType: channelType);
+    }
+
+    private ChatInputState GetState()
+        => BuildState();
+
+    internal void Update()
+    {
+        var state = BuildState();
+        if (HasState && state.Equals(LastState))
+            return;
+
+        HasState = true;
+        LastState = state;
+        StateChangedGate.SendMessage(state);
+    }
+
+    public void Dispose()
+    {
+        StateQueryGate.UnregisterFunc();
+    }
+}

--- a/ChatTwo/Plugin.cs
+++ b/ChatTwo/Plugin.cs
@@ -56,6 +56,7 @@ public sealed class Plugin : IDalamudPlugin
     internal MessageManager MessageManager { get; }
     internal IpcManager Ipc { get; }
     internal ExtraChat ExtraChat { get; }
+    internal TypingIpc TypingIpc { get; }
     internal FontManager FontManager { get; }
 
     internal ServerCore ServerCore { get; }
@@ -97,6 +98,7 @@ public sealed class Plugin : IDalamudPlugin
             Commands = new Commands(this);
             Functions = new GameFunctions.GameFunctions(this);
             Ipc = new IpcManager();
+            TypingIpc = new TypingIpc(this);
             ExtraChat = new ExtraChat(this);
             FontManager = new FontManager();
 
@@ -181,6 +183,7 @@ public sealed class Plugin : IDalamudPlugin
         DebuggerWindow?.Dispose();
         SeStringDebugger?.Dispose();
 
+        TypingIpc?.Dispose();
         ExtraChat?.Dispose();
         Ipc?.Dispose();
         MessageManager?.DisposeAsync().AsTask().Wait();
@@ -193,8 +196,14 @@ public sealed class Plugin : IDalamudPlugin
 
     private void Draw()
     {
+        ChatLogWindow.BeginFrame();
+
         if (Config.HideInLoadingScreens && Condition[ConditionFlag.BetweenAreas])
+        {
+            ChatLogWindow.FinalizeFrame();
+            TypingIpc?.Update();
             return;
+        }
 
         ChatLogWindow.HideStateCheck();
 
@@ -205,6 +214,9 @@ public sealed class Plugin : IDalamudPlugin
         {
             WindowSystem.Draw();
         }
+
+        ChatLogWindow.FinalizeFrame();
+        TypingIpc?.Update();
     }
 
     internal void SaveConfig()


### PR DESCRIPTION
Adds typing state IPC integration for ChatTwo input.

Exposes input state (focus, visibility, text length, channel type, typing status) via IPC endpoints:  
 `ChatTwo.GetChatInputState`  
 `ChatTwo.ChatInputStateChanged`
Enables external plugins/tools to detect user typing, focus, and channel changes in real time.
State updates every frame, no impact on existing chat logic or performance.
Documentation added in `ipc.md`.