### PR TITLE
Mobile/portrait tab pane, smaller changes

### DIFF
--- a/ChatTwo/Http/Frontend/src/components/DynamicTextArea.svelte
+++ b/ChatTwo/Http/Frontend/src/components/DynamicTextArea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-    import {onMount} from "svelte";
-    import {subscribe} from "$lib/utils.svelte";
-    import {chatInput} from "$lib/shared.svelte";
+    import { onMount } from "svelte";
+    import { subscribe } from "$lib/utils.svelte";
+    import { chatInput, messagesList, scrollMessagesToBottom } from "$lib/shared.svelte";
 
     let textarea: HTMLTextAreaElement;
 
@@ -53,8 +53,11 @@
         if (!textarea)
             return;
 
+        const scrolledToBottom = messagesList.scrolledToBottom;
         textarea.style.height = '1px';
         textarea.style.height = `${textarea.scrollHeight + 10}px`; // with +10px extra padding
+        if (scrolledToBottom)
+            scrollMessagesToBottom();
     }
 
     $effect(() => {

--- a/ChatTwo/Http/Frontend/src/components/TabPane.svelte
+++ b/ChatTwo/Http/Frontend/src/components/TabPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { selectedTab, knownTabs, tabPaneState, closeTabPane } from "$lib/shared.svelte";
+    import { selectedTab, knownTabs, tabPaneState, tabPaneAnimationState, closeTabPane, messagesList, scrollMessagesToBottom } from "$lib/shared.svelte";
 
     async function selectTab(index: number) {
         const rawResponse = await fetch('/tab', {
@@ -13,17 +13,40 @@
         // const content = await rawResponse.json();
         // TODO: use the response
     }
+
+    function handleClose() {
+        tabPaneAnimationState.noAnimation = false;
+        closeTabPane();
+    }
+
+    let scrolledToBottom = true;
+    function ontransitionstart() {
+        scrolledToBottom = messagesList.scrolledToBottom;
+    }
+
+    function ontransitionend() {
+        if (scrolledToBottom)
+            scrollMessagesToBottom();
+    }
 </script>
 
-<aside id="tabs" class:visible={tabPaneState.visible}>
+<aside
+    id="tabs"
+    class:no-animation={tabPaneAnimationState.noAnimation}
+    class:hidden={!tabPaneState.visible}
+    {ontransitionstart}
+    {ontransitionend}
+>
     <div class="inner">
         <header>
             <span>Tabs</span>
-            <button type="button" onclick={() => closeTabPane()}>
-                <!-- "x" icon from https://github.com/feathericons/feather, under MIT license -->
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            <button type="button" onclick={() => handleClose()}>
+                <!-- "chevron-left" icon from https://github.com/feathericons/feather, under MIT license -->
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
             </button>
         </header>
+
+        <hr>
 
         <ol id="tabs-list">
             {#each knownTabs as tab}

--- a/ChatTwo/Http/Frontend/src/components/TabPaneOpener.svelte
+++ b/ChatTwo/Http/Frontend/src/components/TabPaneOpener.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import { tabPaneState, openTabPane } from "$lib/shared.svelte";
+    import { tabPaneState, tabPaneAnimationState, openTabPane } from "$lib/shared.svelte";
 
     function onclick() {
+        tabPaneAnimationState.noAnimation = false;
         openTabPane();
     }
 </script>

--- a/ChatTwo/Http/Frontend/src/lib/shared.svelte.ts
+++ b/ChatTwo/Http/Frontend/src/lib/shared.svelte.ts
@@ -11,7 +11,8 @@ export interface ChannelOption {
 
 export const selectedTab: { index: number } = $state({ index: 0 });
 export const knownTabs: ChatTab[] = $state([]);
-export const tabPaneState: { visible: boolean } = $state({ visible: false });
+export const tabPaneState: { visible: boolean } = $state({ visible: true });
+export const tabPaneAnimationState: { noAnimation: boolean } = $state({ noAnimation: true });
 export const persistentTabPabeStateKey = 'chat2_tab_pane_visible';
 
 export function openTabPane() {
@@ -25,3 +26,14 @@ export function closeTabPane() {
 }
 
 export const chatInput: { content: string } = $state({ content: ''} );
+export const messagesList: {
+    element: HTMLElement | null,
+    scrolledToBottom: boolean
+} = $state({ element: null, scrolledToBottom: true });
+
+export function scrollMessagesToBottom() {
+    if (messagesList.element === null)
+        return;
+
+    messagesList.element.lastElementChild?.scrollIntoView();
+}

--- a/ChatTwo/Http/Frontend/static/static/start.css
+++ b/ChatTwo/Http/Frontend/static/static/start.css
@@ -1,4 +1,4 @@
-﻿/* fonts */
+/* fonts */
 @font-face {
     font-family: Lodestone;
     src: url('/files/FFXIV_Lodestone_SSF.ttf') format('truetype');
@@ -125,8 +125,12 @@ aside#tabs {
     background-color: var(--bg-sidebar);
     transition: width 250ms ease;
 
-    width: 0px;
-    &.visible { width: 200px; }
+    width: 200px;
+    &.hidden { width: 0px; }
+
+    &.no-animation {
+        transition: none;
+    }
 
     div.inner {
         width: 200px;
@@ -137,7 +141,6 @@ aside#tabs {
         display: flex;
         align-items: flex-end;
         justify-content: space-between;
-        margin-bottom: 20px;
         font-size: 1.1rem;
         font-weight: 550;
 
@@ -146,6 +149,11 @@ aside#tabs {
             border: none;
             background-color: transparent;
         }
+    }
+
+    hr {
+        margin: 0.6rem 0 0.75rem;
+        border-color: var(--fg-faint);
     }
 
     ol#tabs-list {
@@ -157,6 +165,7 @@ aside#tabs {
     li {
         padding: 3px 5px;
         color: var(--fg-faint);
+        border-radius: 3px;
 
         button {
             width: 100%;
@@ -171,9 +180,13 @@ aside#tabs {
         margin-top: 3px;
     }
 
+    li:has(button:hover) {
+        color: var(--fg);
+        background-color: rgb(from var(--bg-input) r g b / 0.5);
+    }
+
     li.active {
         color: var(--fg);
-        border-radius: 3px;
         background-color: var(--bg-input);
     }
 
@@ -187,6 +200,7 @@ aside#tabs {
 section#messages {
     position: relative;
     flex: 1;
+    min-width: 0;
     min-height: 0;
     padding: 20px;
     line-height: 1.5;
@@ -442,6 +456,17 @@ section#input {
         img {
             width: 1.5rem;
             height: 1.5rem;
+        }
+    }
+
+    aside#tabs {
+        position: fixed;
+        width: 100vw;
+        height: 100vh;
+        z-index: 1000;
+
+        div.inner {
+            width: 100vw;
         }
     }
 }


### PR DESCRIPTION
* tab pane in portrait mode now covers the entire viewport
* tab pane X turned into a chevron
* added divider between tab pane header and content
* changed default tab pane state to open
* added code to scroll messages back to bottom after tab pane animation and message input resize