### PR TITLE
Recover off-screen window position after display layout change

### DIFF
--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -3236,7 +3236,25 @@ namespace ChatTwo.Resources {
                 return ResourceManager.GetString("Options_PrintChangelog_Name", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Snaps the chat window back to the primary monitor&apos;s top-left corner. Useful when the window has drifted off-screen after a display layout change (monitor disconnected, resolution changed). The plugin also runs an automatic bounds check once per session — this button is the manual backup if anything still ends up unreachable..
+        /// </summary>
+        internal static string Options_ResetWindowPosition_Description {
+            get {
+                return ResourceManager.GetString("Options_ResetWindowPosition_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Reset window position.
+        /// </summary>
+        internal static string Options_ResetWindowPosition_Name {
+            get {
+                return ResourceManager.GetString("Options_ResetWindowPosition_Name", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Replaces words with their emote version, currently supports BetterTTV..
         /// </summary>

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -469,6 +469,12 @@
     <data name="Options_KeybindMode_Description">
         <value>The way in which {0} should handle keybinds.</value>
     </data>
+    <data name="Options_ResetWindowPosition_Name">
+        <value>Reset window position</value>
+    </data>
+    <data name="Options_ResetWindowPosition_Description">
+        <value>Snaps the chat window back to the primary monitor's top-left corner. Useful when the window has drifted off-screen after a display layout change (monitor disconnected, resolution changed). The plugin also runs an automatic bounds check once per session — this button is the manual backup if anything still ends up unreachable.</value>
+    </data>
     <data name="Options_Miscellaneous_Tab">
         <value>Miscellaneous</value>
     </data>

--- a/ChatTwo/Ui/ChatLogWindow.cs
+++ b/ChatTwo/Ui/ChatLogWindow.cs
@@ -63,6 +63,13 @@ public sealed class ChatLogWindow : Window
     public Vector2 LastWindowPos { get; private set; } = Vector2.Zero;
     public Vector2 LastWindowSize { get; private set; } = Vector2.Zero;
 
+    // Window position recovery: guards against off-screen positions after a
+    // display layout change (monitor disconnected, resolution changed). The
+    // first draw after plugin load runs a one-shot bounds check; the manual
+    // reset button in the settings forces a snap regardless.
+    private bool DidOnLoadBoundsCheck;
+    internal bool RequestPositionReset { get; set; }
+
     public unsafe ImGuiViewport* LastViewport;
     private bool WasDocked;
 
@@ -538,6 +545,21 @@ public sealed class ChatLogWindow : Window
         var resized = LastWindowSize != currentSize;
         LastWindowSize = currentSize;
         LastWindowPos = ImGui.GetWindowPos();
+
+        // Manual reset has priority and snaps the window unconditionally.
+        // Otherwise the one-shot on-load check only fires when the persisted
+        // position has no overlap with the visible viewport.
+        if (RequestPositionReset)
+        {
+            RequestPositionReset = false;
+            DidOnLoadBoundsCheck = true;
+            ApplySafeDefaultPosition("manual-reset");
+        }
+        else if (!DidOnLoadBoundsCheck)
+        {
+            DidOnLoadBoundsCheck = true;
+            EnsureWindowOnScreen("on-load");
+        }
 
         if (resized)
             LastResize.Restart();
@@ -1845,5 +1867,43 @@ public sealed class ChatLogWindow : Window
     {
         var hashCode = $"{Salt}{playerName}{worldId}".GetHashCode();
         return $"Player {hashCode:X8}";
+    }
+
+    // Snap threshold in pixels: at least this much of the window must overlap
+    // a visible viewport so the user can still grab the first tab header.
+    // Below the threshold the window is considered off-screen.
+    private const int OnScreenMinOverlapX = 100;
+    private const int OnScreenMinOverlapY = 40;
+
+    // Default snap position relative to the primary viewport (top-left with a
+    // safety margin from the game title bar).
+    private static readonly Vector2 SafeDefaultOffset = new(50, 50);
+
+    private void EnsureWindowOnScreen(string source)
+    {
+        if (LastWindowSize.X < 1 || LastWindowSize.Y < 1)
+            return;
+
+        var viewport = ImGui.GetMainViewport();
+        var visibleMin = viewport.WorkPos;
+        var visibleMax = viewport.WorkPos + viewport.WorkSize;
+
+        var overlapMin = Vector2.Max(LastWindowPos, visibleMin);
+        var overlapMax = Vector2.Min(LastWindowPos + LastWindowSize, visibleMax);
+        var overlap = overlapMax - overlapMin;
+
+        if (overlap.X >= OnScreenMinOverlapX && overlap.Y >= OnScreenMinOverlapY)
+            return;
+
+        ApplySafeDefaultPosition(source);
+    }
+
+    private void ApplySafeDefaultPosition(string source)
+    {
+        var viewport = ImGui.GetMainViewport();
+        var safePos = viewport.WorkPos + SafeDefaultOffset;
+        Position = safePos;
+        Plugin.Log.Information(
+            $"[Window-Recovery] {source}: snapping main window from {LastWindowPos} (size {LastWindowSize}) to {safePos}.");
     }
 }

--- a/ChatTwo/Ui/Settings.cs
+++ b/ChatTwo/Ui/Settings.cs
@@ -42,7 +42,7 @@ public sealed class SettingsWindow : Window
             new Tabs(Plugin, Mutable),
             new Database(Plugin, Mutable),
             new Webinterface(Plugin, Mutable),
-            new Miscellaneous(Mutable),
+            new Miscellaneous(Plugin, Mutable),
             new Changelog(Mutable),
             new About()
         ];

--- a/ChatTwo/Ui/SettingsTabs/Miscellaneous.cs
+++ b/ChatTwo/Ui/SettingsTabs/Miscellaneous.cs
@@ -4,8 +4,9 @@ using Dalamud.Bindings.ImGui;
 
 namespace ChatTwo.Ui.SettingsTabs;
 
-internal sealed class Miscellaneous(Configuration mutable) : ISettingsTab
+internal sealed class Miscellaneous(Plugin plugin, Configuration mutable) : ISettingsTab
 {
+    private Plugin Plugin { get; } = plugin;
     private Configuration Mutable { get; } = mutable;
     public string Name => Language.Options_Miscellaneous_Tab + "###tabs-miscellaneous";
 
@@ -57,6 +58,11 @@ internal sealed class Miscellaneous(Configuration mutable) : ISettingsTab
 
         ImGui.Checkbox(Language.Options_SortAutoTranslate_Name, ref Mutable.SortAutoTranslate);
         ImGuiUtil.HelpText(Language.Options_SortAutoTranslate_Description);
+        ImGui.Spacing();
+
+        if (ImGui.Button(Language.Options_ResetWindowPosition_Name))
+            Plugin.ChatLogWindow.RequestPositionReset = true;
+        ImGuiUtil.HelpText(Language.Options_ResetWindowPosition_Description);
         ImGui.Spacing();
     }
 }


### PR DESCRIPTION
## Summary

The persisted ImGui window position can end up off-screen when the user disconnects a monitor or changes display resolution between sessions. The chat log window then renders outside the visible viewport, with no drag handles available. Right now the only recovery path is editing the plugin's JSON config by hand, which is rough for users who don't know it exists.

This PR adds two layers of safety.

**Automatic one-shot bounds check on the first draw after plugin load.** When the persisted position has less than 100x40 pixel overlap with the primary viewport, the window snaps to a safe default offset (top-left plus 50px). Logged at info level, so users can see in `/xllog` that the recovery actually happened.

**Manual "Reset window position" button under the Miscellaneous settings tab.** A deliberate escape hatch for edge cases the automatic check doesn't catch: DPI scaling differences, multi-viewport oddities, and whatever else hasn't shown up yet.

Pop-outs are intentionally not part of this path. They are non-persistent (cleared on plugin reload), so they can't survive a session boundary in an off-screen state.

## Repro

Linux/Wayland, Plasma, 3-monitor setup. Place the window on monitor 2, physically disconnect monitor 2 and 3, restart the game.

Before this PR: the window stays anchored to its old x-coordinate and is reachable only by reconnecting a display or hand-editing the config. With this PR applied: the bounds check fires on the first draw and the window snaps onto the remaining display.

## Notes

- **Translations:** only the English source string is in this PR. The other locales are picked up via the existing Crowdin pipeline.
- **Constructor signature change:** the `Miscellaneous` settings tab changes from `(Configuration)` to `(Plugin, Configuration)`, matching the pattern already used by ChatLog, Emote, ChatColours, Tabs, Database and Webinterface tabs. `Settings.cs` is updated accordingly.
- **Origin:** originally landed in JonKazama-Hellion/HellionChat@7012e8c on the standalone fork. Cherry-picked back here because the bug lives on the same code path, and it felt wrong to keep the fix on the fork side only.