### PR TITLE
Add optional QuickSymbols IPC support

### DIFF
--- a/ChatTwo/Ipc/QuickSymbolsIpc.cs
+++ b/ChatTwo/Ipc/QuickSymbolsIpc.cs
@@ -1,0 +1,112 @@
+using ChatTwo.Ui.Handler;
+using Dalamud.Plugin.Ipc;
+
+namespace ChatTwo;
+
+public sealed class QuickSymbolsIpc : IDisposable
+{
+    private const string Owner = "ChatTwo";
+    private const string WatchInput = "QuickSymbols.WatchInput";
+    private const string ClosePicker = "QuickSymbols.ClosePicker";
+    private const string SymbolSelected = "QuickSymbols.SymbolSelected";
+
+    private ICallGateSubscriber<string, bool>? watch;
+    private ICallGateSubscriber<string, bool>? close;
+    private ICallGateSubscriber<string, string, object?>? selected;
+    private Action<string, string>? onSelected;
+
+    // This is for tracking the input that most recently advertised itself as active.
+    // QuickSymbols will send the selected symbol back ONLY through IPC; ChatTwo will still own the buffer and caret.
+    private InputHandler? input;
+
+    public QuickSymbolsIpc(Plugin _)
+    {
+        Register();
+    }
+
+    public void Watch(InputHandler handler, bool state)
+    {
+        // A false state means that this handler should no longer receive symbols.
+        // This will preserve any other handler that became operational post this one.
+        if (!state)
+        {
+            if (ReferenceEquals(input, handler))
+                input = null;
+
+            return;
+        }
+
+        input = handler;
+
+        try
+        {
+            // The active input tells QuickSymbols that it is safe to react
+            // to the user QuickSymbols keybind but only for this owner and while the input is active.
+            watch?.InvokeFunc(Owner);
+        }
+        catch
+        {
+            // QuickSymbols is optional. Won't do anything unless called.
+        }
+    }
+
+    private void Register()
+    {
+        try
+        {
+            // These subscribers will only be utilized if QuickSymbols is loaded
+            // and the IPC available. Otherwise, ChatTwo will carry on functioning as it normally does.
+            watch = Plugin.Interface.GetIpcSubscriber<string, bool>(WatchInput);
+            close = Plugin.Interface.GetIpcSubscriber<string, bool>(ClosePicker);
+            selected = Plugin.Interface.GetIpcSubscriber<string, string, object?>(SymbolSelected);
+
+            // QuickSymbols doesnt modify ChatTwo input itself. It simply displays
+            // the chosen symbol in this location and then ChatTwo should handle its insertion via its own InputHandler.
+            onSelected = OnSelected;
+            selected.Subscribe(onSelected);
+        }
+        catch (Exception ex)
+        {
+            Plugin.Log.Debug(ex, "QuickSymbols IPC could not be registered.");
+        }
+    }
+
+    private void Close()
+    {
+        try
+        {
+            // This will terminate any picker session that was initiated for ChatTwo.
+            // It should prevent outdated QuickSymbols target from remaining once ChatTwo has been unloaded.
+            close?.InvokeFunc(Owner);
+        }
+        catch
+        {
+
+        }
+    }
+
+    private void OnSelected(string owner, string symbol)
+    {
+        // Multiple plugins may pick up on the same occurrence,
+        // therefore the owner key is to ensure that each setup stays separate.
+        if (owner != Owner || string.IsNullOrEmpty(symbol))
+            return;
+
+        // This approach is to ensure that the text buffer, blinking cursor and the
+        // restoration of focus are all managed by ChatTwo itself.
+        // For this to work, it channels the input directly through ChatTwo internal mechanisms.
+        input?.InsertText(symbol);
+    }
+
+    public void Dispose()
+    {
+        // Any active picker is closed before the IPC subscriber goes away.
+        Close();
+
+        if (selected != null && onSelected != null)
+        {
+            selected.Unsubscribe(onSelected);
+            onSelected = null;
+        }
+    }
+}

--- a/ChatTwo/Plugin.cs
+++ b/ChatTwo/Plugin.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
 using ChatTwo.Http;
-using ChatTwo.Ipc;
 using ChatTwo.Resources;
 using ChatTwo.Ui;
 using ChatTwo.Ui.ChatLog;
@@ -62,6 +61,7 @@ public sealed class Plugin : IDalamudPlugin
     public IpcManager Ipc { get; }
     public ExtraChat ExtraChat { get; }
     public TypingIpc TypingIpc { get; }
+    public QuickSymbolsIpc QuickSymbols { get; }
     public FontManager FontManager { get; }
 
     public readonly ServerCore ServerCore;
@@ -132,6 +132,7 @@ public sealed class Plugin : IDalamudPlugin
             Functions = new GameFunctions.GameFunctions(this);
             Ipc = new IpcManager();
             TypingIpc = new TypingIpc(this);
+            QuickSymbols = new QuickSymbolsIpc(this);
             ExtraChat = new ExtraChat();
             FontManager = new FontManager();
 
@@ -216,6 +217,7 @@ public sealed class Plugin : IDalamudPlugin
         DebuggerWindow?.Dispose();
         SeStringDebugger?.Dispose();
 
+        QuickSymbols?.Dispose();
         TypingIpc?.Dispose();
         ExtraChat?.Dispose();
         Ipc?.Dispose();

--- a/ChatTwo/Ui/Handler/InputHandler.cs
+++ b/ChatTwo/Ui/Handler/InputHandler.cs
@@ -1,5 +1,6 @@
-﻿using System.Numerics;
+using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Text;
 using ChatTwo.Code;
 using ChatTwo.GameFunctions;
 using ChatTwo.GameFunctions.Types;
@@ -31,6 +32,11 @@ public class InputHandler
 
     public string ChatInput = string.Empty;
 
+    private string? pendingText;
+    private int pendingPos = -1;
+    private int qsFocusFrames;
+    private int qsCaretFrames;
+
     public bool FocusedPreview;
     public bool Activate;
     public bool InputFocused;
@@ -55,6 +61,19 @@ public class InputHandler
         ChunkHandler = new ChunkHandler(plugin);
         PayloadHandler = new PayloadHandler(this);
         AutoCompleteHandler = new AutoCompleteHandler(this);
+    }
+
+    public void InsertText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return;
+
+        pendingText += text;
+        pendingPos = CursorPos;
+        Activate = true;
+        ActivatePos = CursorPos;
+        qsFocusFrames = 6;
+        qsCaretFrames = 90;
     }
 
     public void DrawInputArea(Tab activeTab, float inputWidth, ref bool tellSpecial)
@@ -87,9 +106,12 @@ public class InputHandler
         using (ImRaii.PushColor(ImGuiCol.Text, push ? ColourUtil.RgbaToAbgr(inputColour!.Value) : 0, push))
         {
             var isChatEnabled = activeTab is { InputDisabled: false };
-            if (isChatEnabled && (Activate || FocusedPreview))
+            if (isChatEnabled && (Activate || FocusedPreview || qsFocusFrames > 0))
             {
                 FocusedPreview = false;
+                if (qsFocusFrames > 0)
+                    qsFocusFrames--;
+
                 ImGui.SetKeyboardFocusHere();
             }
 
@@ -100,8 +122,28 @@ public class InputHandler
                 ImGui.SetNextItemWidth(inputWidth);
                 ImGui.InputTextWithHint("##chat2-input", isChatEnabled ? "": Language.ChatLog_DisabledInput, ref ChatInput, 500, flags, Callback);
             }
-            var inputActive = ImGui.IsItemActive();
+            var inputMin = ImGui.GetItemRectMin();
+            var inputMax = ImGui.GetItemRectMax();
+            var inputActive = ImGui.IsItemActive() || ImGui.IsItemFocused();
             InputFocused = isChatEnabled && inputActive;
+
+            if (qsCaretFrames > 0)
+                qsCaretFrames--;
+
+            Plugin.QuickSymbols.Watch(this, isChatEnabled && (inputActive || qsFocusFrames > 0 || qsCaretFrames > 0));
+
+            if (!inputActive && qsCaretFrames > 0)
+            {
+                var caretAlpha = (ImGui.GetTime() % 1.0) < 0.5 ? 0.95f : 0.35f;
+                var textWidth = ImGui.CalcTextSize(ChatInput).X;
+                var caretX = MathF.Min(inputMax.X - 5f, inputMin.X + 8f + textWidth);
+                var caretY = inputMin.Y + 4f;
+                ImGui.GetWindowDrawList().AddLine(
+                    new Vector2(caretX, caretY),
+                    new Vector2(caretX, inputMax.Y - 4f),
+                    ImGui.GetColorU32(new Vector4(1f, 1f, 1f, caretAlpha)),
+                    1f);
+            }
 
             var tooltipDraw = Plugin.Config.PreviewPosition is PreviewPosition.Tooltip && Plugin.InputPreview.IsDrawable;
             if (tooltipDraw && ImGui.IsItemHovered())
@@ -230,6 +272,19 @@ public class InputHandler
             data.CursorPos = ActivatePos > -1 ? ActivatePos : ChatInput.Length;
             data.SelectionStart = data.SelectionEnd = data.CursorPos;
             ActivatePos = -1;
+        }
+
+        if (pendingText != null)
+        {
+            var insert = pendingText;
+            var pos = pendingPos > -1 ? Math.Min(pendingPos, data.BufTextLen) : data.CursorPos;
+
+            pendingText = null;
+            pendingPos = -1;
+
+            data.InsertChars(pos, insert);
+            data.CursorPos = pos + Encoding.UTF8.GetByteCount(insert);
+            data.SelectionStart = data.SelectionEnd = data.CursorPos;
         }
 
         Plugin.CommandHelpWindow.IsOpen = false;


### PR DESCRIPTION
This pull request introduces [QuickSymbols](https://github.com/LatencyBryer/QuickSymbols) plugin IPC integration for ChatTwo.

Essentially, the aim is to enable ChatTwo users to launch the QuickSymbols popup-list when the ChatTwo input is focused, pick symbols and then have ChatTwo place those chosen symbols into its own text entry field.

ChatTwo has its own text input, focus, selection and caret state, so the safest integration is for ChatTwo to opt in via IPC and perform the final insertion on its side.

### How it works

No clipboard, synthetic input or external ImGui input writing is used.
ChatTwo monitors its own input while active and informs QuickSymbols via `QuickSymbols.WatchInput`.

Upon pressing the QuickSymbols keybind it will open its own popup for the ChatTwo owner. When you select a symbol, QuickSymbols sends it back through `QuickSymbols.SymbolSelected` and ChatTwo inserts it through its own text input handler.

### Changes Made

- Added a small `QuickSymbolsIpc` integration class
- Registers optional QuickSymbols IPC subscribers
- Lets ChatTwo advertise its active input through `QuickSymbols.WatchInput`
- Receives selected symbols through `QuickSymbols.SymbolSelected`
- Inserts symbols through ChatTwo own input path

### Notes
The integration is completely optional. If QuickSymbols is not installed, not loaded or does not expose the expected IPC, ChatTwo will continue to work normally.
If you want, you can get the full QuickSymbols/IPC documentation I wrote [here.](https://github.com/LatencyBryer/QuickSymbols/blob/main/IPC.md)

> QuickSymbols IPC support itself is currently pending in a separate Dalamud plugin [PR.](https://github.com/goatcorp/DalamudPluginsD17/pull/8899) This integration with ChatTwo will only become active in-game once that update is merged. _(Jun 15, 07:04 PM EST)_
QuickSymbols IPC support merged on Stable. _(Jun 15, 10:45 PM EST)_