### PR TITLE
Feature: checkerboard rows option for the modern layout

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -68,6 +68,8 @@ public class Configuration : IPluginConfiguration
     public bool NativeItemTooltips = true;
     public bool PrettierTimestamps = true;
     public bool MoreCompactPretty;
+    public bool CheckerboardRows;
+    public uint CheckerboardColor = 0xFFFFFF0A;
     public bool HideSameTimestamps;
     public bool ShowNoviceNetwork;
     public bool SidebarTabView;
@@ -163,6 +165,8 @@ public class Configuration : IPluginConfiguration
         NativeItemTooltips = other.NativeItemTooltips;
         PrettierTimestamps = other.PrettierTimestamps;
         MoreCompactPretty = other.MoreCompactPretty;
+        CheckerboardRows = other.CheckerboardRows;
+        CheckerboardColor = other.CheckerboardColor;
         HideSameTimestamps = other.HideSameTimestamps;
         ShowNoviceNetwork = other.ShowNoviceNetwork;
         SidebarTabView = other.SidebarTabView;

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -2185,6 +2185,33 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Alternate row colour.
+        /// </summary>
+        internal static string Options_CheckerboardRows_Color {
+            get {
+                return ResourceManager.GetString("Options_CheckerboardRows_Color", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Alternate the background colour of every other message to make rows easier to tell apart..
+        /// </summary>
+        internal static string Options_CheckerboardRows_Description {
+            get {
+                return ResourceManager.GetString("Options_CheckerboardRows_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Checkerboard rows.
+        /// </summary>
+        internal static string Options_CheckerboardRows_Name {
+            get {
+                return ResourceManager.GetString("Options_CheckerboardRows_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Clear the message history database.
         /// </summary>
         internal static string Options_ClearDatabase_Button {

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -163,6 +163,15 @@
     <data name="Options_MoreCompactPretty_Description">
         <value>Reduce the spacing between messages.</value>
     </data>
+    <data name="Options_CheckerboardRows_Name">
+        <value>Checkerboard rows</value>
+    </data>
+    <data name="Options_CheckerboardRows_Description">
+        <value>Alternate the background colour of every other message to make rows easier to tell apart.</value>
+    </data>
+    <data name="Options_CheckerboardRows_Color">
+        <value>Alternate row colour</value>
+    </data>
     <data name="Options_ShowNoviceNetwork_Name">
         <value>Show Novice Network join button</value>
     </data>

--- a/ChatTwo/Ui/ChatLog/ChatLog.Window.cs
+++ b/ChatTwo/Ui/ChatLog/ChatLog.Window.cs
@@ -625,10 +625,17 @@ public partial class ChatLog : Window, IChatWindow
         var oldItemSpacing = ImGui.GetStyle().ItemSpacing;
         var oldCellPadding = ImGui.GetStyle().CellPadding;
 
+        var checkerboard = Plugin.Config.CheckerboardRows;
+        var tableFlags = ImGuiTableFlags.PreciseWidths;
+        if (checkerboard)
+            tableFlags |= ImGuiTableFlags.RowBg;
+
+        using (ImRaii.PushColor(ImGuiCol.TableRowBg, Vector4.Zero, checkerboard))
+        using (ImRaii.PushColor(ImGuiCol.TableRowBgAlt, ColourUtil.RgbaToVector4(Plugin.Config.CheckerboardColor) ?? Vector4.Zero, checkerboard))
         using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, Vector2.Zero))
         using (ImRaii.PushStyle(ImGuiStyleVar.CellPadding, oldCellPadding with { Y = 0 }, compact))
         {
-            using var table = ImRaii.Table("timestamp-table", 2, ImGuiTableFlags.PreciseWidths);
+            using var table = ImRaii.Table("timestamp-table", 2, tableFlags);
             if (!table.Success)
                 return;
 

--- a/ChatTwo/Ui/SettingsTabs/Display.cs
+++ b/ChatTwo/Ui/SettingsTabs/Display.cs
@@ -102,6 +102,13 @@ public sealed class Display : ISettingsTab
             using var _ = ImRaii.PushIndent();
             ImGuiUtil.OptionCheckbox(ref Mutable.MoreCompactPretty, Language.Options_MoreCompactPretty_Name, Language.Options_MoreCompactPretty_Description);
             ImGuiUtil.OptionCheckbox(ref Mutable.HideSameTimestamps, Language.Options_HideSameTimestamps_Name, Language.Options_HideSameTimestamps_Description);
+            ImGuiUtil.OptionCheckbox(ref Mutable.CheckerboardRows, Language.Options_CheckerboardRows_Name, Language.Options_CheckerboardRows_Description);
+            if (Mutable.CheckerboardRows)
+            {
+                var checkerColour = ColourUtil.RgbaToVector4(Mutable.CheckerboardColor)!.Value;
+                if (ImGui.ColorEdit4(Language.Options_CheckerboardRows_Color, ref checkerColour, ImGuiColorEditFlags.NoInputs))
+                    Mutable.CheckerboardColor = ColourUtil.Vector4ToRgba(checkerColour);
+            }
         }
         ImGui.Spacing();
 

--- a/ChatTwo/Util/ColourUtil.cs
+++ b/ChatTwo/Util/ColourUtil.cs
@@ -40,6 +40,14 @@ public static class ColourUtil
         => ComponentsToRgba((byte)Math.Round(col.X * 255), (byte)Math.Round(col.Y * 255), (byte)Math.Round(col.Z * 255));
 
     /// <summary>
+    /// Converts a Vector4 to an RGBA color value.
+    /// </summary>
+    /// <param name="col">The color</param>
+    /// <returns>Color as byte representation RR GG BB AA</returns>
+    public static uint Vector4ToRgba(Vector4 col)
+        => ComponentsToRgba((byte)Math.Round(col.X * 255), (byte)Math.Round(col.Y * 255), (byte)Math.Round(col.Z * 255), (byte)Math.Round(col.W * 255));
+
+    /// <summary>
     /// Converts a Vector4 to an ABGR color value.
     /// </summary>
     /// <param name="col">The color</param>


### PR DESCRIPTION
Adds a "Checkerboard rows" sub-option under the prettier timestamps setting: every other message row gets a configurable background color, which makes rows easier to tell apart in busy chat.

Implementation is small on purpose: when enabled, the timestamp table gets ImGuiTableFlags.RowBg and the two row colors are pushed around it (TableRowBg transparent, TableRowBgAlt = the configured color). One stripe per message, so wrapped multi-line messages stay on a single stripe.

Default alternate row background is white at ~4%.

Settings UI mirrors the existing "More compact modern layout" sub-option, English strings added to the resx. No config migration needed.

Tested in game:
- toggling live
- per-message striping with wrapped messages
- alpha on a translucent window

Disclosure:
This was co-developed with AI assistance (Claude Code).
I've reviewed the code and tested it in game myself.

Preview Chat:
<img width="666" height="693" alt="image" src="https://github.com/user-attachments/assets/224e0662-29c0-4267-9cc3-6713903ba64c" />


Preview Settings:
<img width="481" height="268" alt="image" src="https://github.com/user-attachments/assets/249e4bf1-8608-41b8-93c1-ee9d4c49f068" />

