### PR TITLE
Feature: message styling IPC for per-message background, fade and hide

### DIFF
--- a/ChatTwo/Ipc/StyleIpc.cs
+++ b/ChatTwo/Ipc/StyleIpc.cs
@@ -1,0 +1,64 @@
+using Dalamud.Plugin.Ipc;
+
+namespace ChatTwo.Ipc;
+
+using MessageStyle = (uint BackgroundRgba, float Alpha);
+
+public sealed class StyleIpc : IDisposable
+{
+    private const int Version = 1;
+
+    private ICallGateProvider<int> VersionGate { get; }
+    private ICallGateProvider<string, object?> SetProviderGate { get; }
+
+    // Written from the registering plugin's thread, read from the message
+    // processing thread; reference reads/writes are atomic.
+    private ICallGateSubscriber<string, string, ulong, ushort, string, string, MessageStyle>? Provider;
+
+    public bool HasProvider => Provider != null;
+
+    public StyleIpc()
+    {
+        VersionGate = Plugin.Interface.GetIpcProvider<int>("ChatTwo.StyleVersion");
+        VersionGate.RegisterFunc(() => Version);
+
+        SetProviderGate = Plugin.Interface.GetIpcProvider<string, object?>("ChatTwo.SetMessageStyleProvider");
+        SetProviderGate.RegisterAction(SetProvider);
+    }
+
+    private void SetProvider(string gateName)
+    {
+        Provider = string.IsNullOrEmpty(gateName)
+            ? null
+            : Plugin.Interface.GetIpcSubscriber<string, string, ulong, ushort, string, string, MessageStyle>(gateName);
+    }
+
+    /// <summary>
+    /// Asks the registered style provider for a background colour (RGBA, 0 for
+    /// none) and alpha (1 = normal, 0 &lt; a &lt; 1 = faded, &lt;= 0 = hidden
+    /// from the log) for a message. Called once per message on the message
+    /// processing thread; providers must be thread-safe.
+    /// </summary>
+    public MessageStyle Evaluate(string senderName, string senderWorld, ulong contentId, ushort chatType, string senderRaw, string contentText)
+    {
+        if (Provider is not { } provider)
+            return (0, 1f);
+
+        try
+        {
+            return provider.InvokeFunc(senderName, senderWorld, contentId, chatType, senderRaw, contentText);
+        }
+        catch (Exception)
+        {
+            // A broken or unloaded provider must never break message
+            // ingestion; unstyled is the safe fallback.
+            return (0, 1f);
+        }
+    }
+
+    public void Dispose()
+    {
+        SetProviderGate.UnregisterAction();
+        VersionGate.UnregisterFunc();
+    }
+}

--- a/ChatTwo/Message.cs
+++ b/ChatTwo/Message.cs
@@ -34,6 +34,11 @@ public partial class Message
     public Dictionary<Guid, float?> Height { get; } = new();
     public Dictionary<Guid, bool> IsVisible { get; } = new();
 
+    // Set once at ingestion via the message styling IPC; messages loaded from
+    // the database render unstyled.
+    public uint StyleBackground; // RGBA, 0 = no background
+    public float StyleAlpha = 1f; // <= 0 hides the message from the log (it stays stored)
+
     public Message(ulong receiver, ulong contentId, ulong accountId, ChatCode code, List<Chunk> sender, List<Chunk> content, SeString senderSource, SeString contentSource)
     {
         var extraChatChannel = ExtractExtraChatChannel(contentSource);

--- a/ChatTwo/MessageManager.cs
+++ b/ChatTwo/MessageManager.cs
@@ -7,6 +7,7 @@ using ChatTwo.Util;
 using Dalamud.Game.Chat;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Hooking;
 using Dalamud.Interface.ImGuiNotification;
 using Dalamud.Plugin.Services;
@@ -275,6 +276,18 @@ public class MessageManager : IAsyncDisposable
 
         var contentChunks = ChunkUtil.ToChunks(pendingMessage.Content, ChunkSource.Content, chatCode.Type).ToList();
         var message = new Message(CurrentContentId, pendingMessage.ContentId, pendingMessage.AccountId, chatCode, senderChunks, contentChunks, pendingMessage.Sender, pendingMessage.Content);
+
+        if (Plugin.StyleIpc.HasProvider)
+        {
+            var senderPayload = pendingMessage.Sender.Payloads.OfType<PlayerPayload>().FirstOrDefault();
+            (message.StyleBackground, message.StyleAlpha) = Plugin.StyleIpc.Evaluate(
+                senderPayload?.PlayerName ?? "",
+                senderPayload?.World.ValueNullable?.Name.ExtractText() ?? "",
+                pendingMessage.ContentId,
+                (ushort) pendingMessage.LogKind,
+                pendingMessage.Sender.TextValue,
+                pendingMessage.Content.TextValue);
+        }
 
         var isBattle = message.Code.IsBattle();
         var isCraftOrGather = message.Code.IsCraftOrGather();

--- a/ChatTwo/Plugin.cs
+++ b/ChatTwo/Plugin.cs
@@ -62,6 +62,7 @@ public sealed class Plugin : IDalamudPlugin
     public IpcManager Ipc { get; }
     public ExtraChat ExtraChat { get; }
     public TypingIpc TypingIpc { get; }
+    public StyleIpc StyleIpc { get; }
     public FontManager FontManager { get; }
 
     public readonly ServerCore ServerCore;
@@ -130,6 +131,9 @@ public sealed class Plugin : IDalamudPlugin
 
             Commands = new Commands();
             Functions = new GameFunctions.GameFunctions(this);
+            // Constructed before IpcManager so the style gates are already
+            // registered when the ChatTwo.Available broadcast fires.
+            StyleIpc = new StyleIpc();
             Ipc = new IpcManager();
             TypingIpc = new TypingIpc(this);
             ExtraChat = new ExtraChat();
@@ -217,6 +221,7 @@ public sealed class Plugin : IDalamudPlugin
         SeStringDebugger?.Dispose();
 
         TypingIpc?.Dispose();
+        StyleIpc?.Dispose();
         ExtraChat?.Dispose();
         Ipc?.Dispose();
         MessageManager?.DisposeAsync().AsTask().Wait();

--- a/ChatTwo/Ui/ChatLog/ChatLog.Window.cs
+++ b/ChatTwo/Ui/ChatLog/ChatLog.Window.cs
@@ -652,6 +652,10 @@ public partial class ChatLog : Window, IChatWindow
 
     private void DrawMessages(Tab tab, PayloadHandler handler, bool isTable, bool moreCompact = false, float oldCellPaddingY = 0)
     {
+        // Set while the classic-layout background has the draw list split, so
+        // an exception mid-message can't leave the list split (the next
+        // frame's split would then assert inside ImGui).
+        var backgroundSplitActive = false;
         try
         {
             // This may produce ApplicationException which is catched below.
@@ -679,6 +683,16 @@ public partial class ChatLog : Window, IChatWindow
                 {
                     message.Height[tab.Identifier] = null;
                     message.IsVisible[tab.Identifier] = false;
+                }
+
+                // Hidden by the message style provider; the message stays
+                // stored, logged and exported. Skipped before duplicate
+                // collapsing so a hidden message neither anchors nor counts
+                // toward a collapse run.
+                if (message.StyleAlpha <= 0)
+                {
+                    message.IsVisible[tab.Identifier] = false;
+                    continue;
                 }
 
                 if (Plugin.Config.CollapseDuplicateMessages)
@@ -760,6 +774,30 @@ public partial class ChatLog : Window, IChatWindow
                     message.IsVisible[tab.Identifier] = nowVisible;
                 }
 
+                var applyBackground = message.StyleBackground != 0;
+                if (applyBackground && isTable)
+                    ImGui.TableSetBgColor(ImGuiTableBgTarget.RowBg0, ColourUtil.RgbaToAbgr(message.StyleBackground));
+
+                // In the classic layout the background's size is only known
+                // after the message is drawn (word wrapping), so draw the text
+                // into the upper draw list channel and fill the rect behind it
+                // afterwards.
+                var drawList = ImGui.GetWindowDrawList();
+                var splitBackground = applyBackground && !isTable;
+                var backgroundStart = Vector2.Zero;
+                var backgroundWidth = 0f;
+                if (splitBackground)
+                {
+                    backgroundStart = ImGui.GetCursorScreenPos();
+                    backgroundWidth = ImGui.GetContentRegionAvail().X;
+                    drawList.ChannelsSplit(2);
+                    drawList.ChannelsSetCurrent(1);
+                    backgroundSplitActive = true;
+                }
+
+                // Faded by the message style provider.
+                using var styleAlpha = ImRaii.PushStyle(ImGuiStyleVar.Alpha, ImGui.GetStyle().Alpha * message.StyleAlpha, message.StyleAlpha < 1f);
+
                 if (tab.DisplayTimestamp)
                 {
                     var localTime = message.Date.ToLocalTime();
@@ -809,6 +847,15 @@ public partial class ChatLog : Window, IChatWindow
                     InputHandler.ChunkHandler.DrawChunks(message.Content, true, handler, lineWidth);
 
                 message.IsVisible[tab.Identifier] = ImGui.IsItemVisible();
+
+                if (splitBackground)
+                {
+                    drawList.ChannelsSetCurrent(0);
+                    var backgroundEnd = new Vector2(backgroundStart.X + backgroundWidth, ImGui.GetItemRectMax().Y);
+                    drawList.AddRectFilled(backgroundStart, backgroundEnd, ColourUtil.RgbaToAbgr(message.StyleBackground));
+                    drawList.ChannelsMerge();
+                    backgroundSplitActive = false;
+                }
             }
         }
         catch (ApplicationException)
@@ -819,6 +866,11 @@ public partial class ChatLog : Window, IChatWindow
         catch (Exception ex)
         {
             Plugin.Log.Warning(ex, "Error drawing chat log");
+        }
+        finally
+        {
+            if (backgroundSplitActive)
+                ImGui.GetWindowDrawList().ChannelsMerge();
         }
     }
 

--- a/ipc.md
+++ b/ipc.md
@@ -127,3 +127,103 @@ public sealed class TypingIntegration {
 ```
 
 All integrations are called inside of an ImGui `BeginMenu`.
+
+# Message Styling IPC
+
+Plugins can style individual messages in the Chat 2 log — a per-message
+background colour, fading, or hiding a message from display (e.g. group
+highlighting or fading chat from far-away players). Hidden and faded messages
+are only affected visually: they are still stored in the database, exported,
+and shown in the web interface.
+
+- `ChatTwo.StyleVersion`: call this function to retrieve the styling IPC
+  version (currently `1`).
+- `ChatTwo.SetMessageStyleProvider`: call this action with the name of an IPC
+  gate **your** plugin provides. Chat 2 will invoke that gate once per
+  incoming message. Pass an empty string to unregister. Only one provider is
+  active at a time (last writer wins).
+- Re-register when the `ChatTwo.Available` event fires (Chat 2 was loaded or
+  updated).
+
+Your provider gate must have this signature:
+
+```
+(string senderName, string senderWorld, ulong contentId, ushort chatType, string senderRaw, string contentText)
+    → (uint BackgroundRgba, float Alpha)
+```
+
+- `senderName` / `senderWorld`: name and home world taken from the first
+  `PlayerPayload` in the sender SeString; empty strings if the sender is not a
+  player.
+- `contentId`: the sender's content ID, or 0 if unknown. Use it transiently
+  only — the plugin submission rules forbid storing other players' content
+  IDs.
+- `chatType`: the raw `XivChatType` / LogKind value of the message.
+- `senderRaw`: the full sender text including party position or friend-group
+  glyphs and cross-world affixes.
+- `contentText`: the message content as plain text (payloads stripped).
+- Returns: `BackgroundRgba` as `RR GG BB AA` (use `0` for no background) and
+  `Alpha` (`1` = normal, between `0` and `1` = faded, `<= 0` = hidden from the
+  log).
+
+Notes:
+
+- The provider is called **once per message at ingestion, on a background
+  thread** — it must be thread-safe, must not assume the framework thread, and
+  should return quickly. If it throws, the message renders unstyled.
+- Styles are fixed at ingestion. Provider configuration changes only affect
+  new messages, and messages loaded from the database render unstyled.
+- With the timestamp table layout ("prettier timestamps") the background tints
+  the whole row; in the classic layout it is drawn behind the message text.
+
+Example:
+
+```cs
+public sealed class StyleIntegration : IDisposable {
+    private ICallGateSubscriber<int> StyleVersion { get; }
+    private ICallGateSubscriber<string, object?> SetMessageStyleProvider { get; }
+    private ICallGateSubscriber<object?> Available { get; }
+    private ICallGateProvider<string, string, ulong, ushort, string, string, (uint BackgroundRgba, float Alpha)> Provider { get; }
+
+    public StyleIntegration(IDalamudPluginInterface pluginInterface) {
+        StyleVersion = pluginInterface.GetIpcSubscriber<int>("ChatTwo.StyleVersion");
+        SetMessageStyleProvider = pluginInterface.GetIpcSubscriber<string, object?>("ChatTwo.SetMessageStyleProvider");
+        Available = pluginInterface.GetIpcSubscriber<object?>("ChatTwo.Available");
+
+        Provider = pluginInterface.GetIpcProvider<string, string, ulong, ushort, string, string, (uint BackgroundRgba, float Alpha)>("MyPlugin.MessageStyle");
+        Provider.RegisterFunc(GetStyle);
+
+        // Re-register when Chat 2 loads or updates, and register now in case
+        // it is already loaded.
+        Available.Subscribe(Register);
+        Register();
+    }
+
+    private void Register() {
+        try {
+            if (StyleVersion.InvokeFunc() == 1)
+                SetMessageStyleProvider.InvokeAction("MyPlugin.MessageStyle");
+        } catch {
+            // Chat 2 is not loaded.
+        }
+    }
+
+    private (uint BackgroundRgba, float Alpha) GetStyle(string senderName, string senderWorld, ulong contentId, ushort chatType, string senderRaw, string contentText) {
+        // Tint messages from a specific player, fade everyone on Novice
+        // Network, leave everything else untouched.
+        if (senderName == "Haurchefant Greystone")
+            return (0x0080FF30u, 1f);
+
+        return (XivChatType) chatType == XivChatType.NoviceNetwork ? (0u, 0.5f) : (0u, 1f);
+    }
+
+    public void Dispose() {
+        Available.Unsubscribe(Register);
+        try {
+            SetMessageStyleProvider.InvokeAction("");
+        } catch {
+            // Chat 2 is not loaded.
+        }
+    }
+}
+```


### PR DESCRIPTION
Implements the styling IPC proposed in #186.

Two gates, following the typing IPC conventions:


- `ChatTwo.StyleVersion` -> `int` (1)
- `ChatTwo.SetMessageStyleProvider(string gateName)` - registers a provider gate owned by the calling plugin, empty string unregisters, one provider at a time.

The provider is called once per incoming message on the message processing thread and returns `(uint BackgroundRgba, float Alpha)`. Style is stamped on the `Message` at ingestion (not persisted - history from older sessions renders unstyled, no DB change). Provider errors fall back to unstyled.

Rendering:

- Table layout: whole-row tint via `TableSetBgColor(RowBg0)` (composes with the checkerboard PR #187 - explicit row colors take priority over `RowBg` alternation).
- Classic layout: the text is drawn into the upper draw list channel and the rect is filled behind it afterwards, so the background matches the actual wrapped extent from the first frame. The split is merged in a `finally` so a draw exception can't leave the list split.
- Fade: one style-alpha push around the message (text, links, icons).
- Hide: render-only skip - the message stays in the database, exports and the web UI. Skipped before duplicate collapsing so a hidden message can't become the anchor of a collapse run.

`StyleIpc` is constructed before `IpcManager` so the gates already exist when the `ChatTwo.Available` broadcast triggers consumer re-registration.

ipc.md gained a "Message Styling IPC" section with the full contract (signature, threading, alpha semantics) and a consumer example.

Tested in game (with a test provider plugin)
- background/fade/hide in both layouts
- wrapped messages
- pop-out tabs
- hidden messages still present 
- re-registration after a Chat 2 reload

Disclosure:
This was co-developed with AI assistance (Claude Code).
I've reviewed the code and tested it in game myself.

All in one Preview:
<img width="1915" height="777" alt="image" src="https://github.com/user-attachments/assets/bb7c34ab-d50f-49eb-a9b8-ebdaf2bd3c94" />

<img width="670" height="176" alt="image" src="https://github.com/user-attachments/assets/0a85a652-7d27-46a7-bdaa-4167fb90ac05" />
