### PR TITLE
Feature: text glow rendering and an "outline all text" option

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -118,6 +118,13 @@ public class Configuration : IPluginConfiguration
         FontId = new DalamudAssetFontAndFamilyId(DalamudAsset.NotoSansCjkRegular),
         SizePt = 12.75f,
     };
+    // Black at 0x66 alpha; composites to roughly the vanilla glow opacity
+    // across the 8 outline stamps drawn by ImGuiUtil.DrawTextGlow.
+    public const uint DefaultOutlineColor = 0x00000066;
+
+    public bool RenderGlow = true;
+    public bool OutlineAllText;
+    public uint OutlineColor = DefaultOutlineColor;
 
     public float TooltipOffset;
     public float WindowAlpha = 100f;
@@ -198,6 +205,9 @@ public class Configuration : IPluginConfiguration
         JapaneseFontV2 = other.JapaneseFontV2;
         ItalicFontV2 = other.ItalicFontV2;
         SymbolsFontSizeV2 = other.SymbolsFontSizeV2;
+        RenderGlow = other.RenderGlow;
+        OutlineAllText = other.OutlineAllText;
+        OutlineColor = other.OutlineColor;
         TooltipOffset = other.TooltipOffset;
         WindowAlpha = other.WindowAlpha;
         ChatColours = other.ChatColours.ToDictionary(entry => entry.Key, entry => entry.Value);

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -3040,6 +3040,33 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Outline colour.
+        /// </summary>
+        internal static string Options_OutlineAllText_Color {
+            get {
+                return ResourceManager.GetString("Options_OutlineAllText_Color", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Draw an outline around all chat text to improve readability. Text with a game-specified glow colour keeps that colour..
+        /// </summary>
+        internal static string Options_OutlineAllText_Description {
+            get {
+                return ResourceManager.GetString("Options_OutlineAllText_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Outline all text.
+        /// </summary>
+        internal static string Options_OutlineAllText_Name {
+            get {
+                return ResourceManager.GetString("Options_OutlineAllText_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Override Style.
         /// </summary>
         internal static string Options_OverrideStyle_Name {
@@ -3255,6 +3282,24 @@ namespace ChatTwo.Resources {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Draw the glow colour the game specifies around text as a thin outline, like the vanilla chat log..
+        /// </summary>
+        internal static string Options_RenderGlow_Description {
+            get {
+                return ResourceManager.GetString("Options_RenderGlow_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Render text glow.
+        /// </summary>
+        internal static string Options_RenderGlow_Name {
+            get {
+                return ResourceManager.GetString("Options_RenderGlow_Name", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Replaces words with their emote version, currently supports BetterTTV..
         /// </summary>

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -553,6 +553,21 @@
     <data name="Options_ItalicEnabled">
         <value>Use italic font</value>
     </data>
+    <data name="Options_RenderGlow_Name">
+        <value>Render text glow</value>
+    </data>
+    <data name="Options_RenderGlow_Description">
+        <value>Draw the glow colour the game specifies around text as a thin outline, like the vanilla chat log.</value>
+    </data>
+    <data name="Options_OutlineAllText_Name">
+        <value>Outline all text</value>
+    </data>
+    <data name="Options_OutlineAllText_Description">
+        <value>Draw an outline around all chat text to improve readability. Text with a game-specified glow colour keeps that colour.</value>
+    </data>
+    <data name="Options_OutlineAllText_Color">
+        <value>Outline colour</value>
+    </data>
     <data name="AutoTranslate_Search_Hint">
         <value>Search Auto Translate...</value>
     </data>

--- a/ChatTwo/Ui/Handler/ChunkHandler.cs
+++ b/ChatTwo/Ui/Handler/ChunkHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using System.Text;
 using ChatTwo.Code;
 using ChatTwo.Util;
 using Dalamud.Bindings.ImGui;
@@ -140,6 +141,10 @@ public class ChunkHandler
         }
         else
         {
+            var glow = ImGuiUtil.GetGlowColor(chunk);
+            if (glow != null && content.Length > 0)
+                ImGuiUtil.DrawTextGlow(ImGui.GetCursorScreenPos(), glow.Value, Encoding.UTF8.GetBytes(content));
+
             ImGui.TextUnformatted(content);
             ImGuiUtil.PostPayload(chunk, handler);
         }

--- a/ChatTwo/Ui/SeStringDebugger.cs
+++ b/ChatTwo/Ui/SeStringDebugger.cs
@@ -8,6 +8,7 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Utility;
+using Lumina.Text.Payloads;
 using Lumina.Text.ReadOnly;
 using DalamudPartyFinderPayload = Dalamud.Game.Text.SeStringHandling.Payloads.PartyFinderPayload;
 
@@ -183,10 +184,10 @@ public class SeStringDebugger : Window
                 }
                 case RawPayload raw:
                 {
-                    var colorPayload = ColorPayload.From(raw.Data);
+                    var colorPayload = ColorPayload.From(raw.Data) ?? ColorPayload.From(raw.Data, MacroCode.EdgeColor);
                     if (colorPayload != null)
                     {
-                        RenderMetadataDictionary("Link ColorPayload", new Dictionary<string, string?>
+                        RenderMetadataDictionary($"Link ColorPayload ({colorPayload.MacroCode})", new Dictionary<string, string?>
                         {
                             { "Unshifted", colorPayload.UnshiftedColor.ToString("X8") },
                             { "Color", colorPayload.Color.ToString("X8") },

--- a/ChatTwo/Ui/SettingsTabs/Fonts.cs
+++ b/ChatTwo/Ui/SettingsTabs/Fonts.cs
@@ -1,6 +1,7 @@
 using ChatTwo.Resources;
 using ChatTwo.Util;
 using Dalamud;
+using Dalamud.Interface;
 using Dalamud.Interface.FontIdentifier;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility.Raii;
@@ -92,6 +93,24 @@ public class Fonts : ISettingsTab
         ImGuiUtil.FontSizeCombo(Language.Options_SymbolsFontSize_Name, ref Mutable.SymbolsFontSizeV2);
         ImGuiUtil.HelpText(Language.Options_SymbolsFontSize_Description);
 
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.Spacing();
+
+        ImGuiUtil.OptionCheckbox(ref Mutable.RenderGlow, Language.Options_RenderGlow_Name, Language.Options_RenderGlow_Description);
+        ImGui.Spacing();
+
+        ImGuiUtil.OptionCheckbox(ref Mutable.OutlineAllText, Language.Options_OutlineAllText_Name, Language.Options_OutlineAllText_Description);
+        if (Mutable.OutlineAllText)
+        {
+            using var indent = ImRaii.PushIndent();
+            if (ImGuiUtil.IconButton(FontAwesomeIcon.UndoAlt, "outline", Language.Options_ChatColours_Reset))
+                Mutable.OutlineColor = Configuration.DefaultOutlineColor;
+            ImGui.SameLine();
+            var outlineColour = ColourUtil.RgbaToVector4(Mutable.OutlineColor)!.Value;
+            if (ImGui.ColorEdit4(Language.Options_OutlineAllText_Color, ref outlineColour, ImGuiColorEditFlags.NoInputs))
+                Mutable.OutlineColor = ColourUtil.Vector4ToRgba(outlineColour);
+        }
         ImGui.Spacing();
     }
 }

--- a/ChatTwo/Util/ChunkUtil.cs
+++ b/ChatTwo/Util/ChunkUtil.cs
@@ -280,16 +280,32 @@ public static class ChunkUtil
                 case PayloadType.UIForeground:
                     var foregroundPayload = (UIForegroundPayload) payload;
                     if (foregroundPayload.IsEnabled)
-                        foreground.Push(foregroundPayload.UIColor.Value.Dark);
+                    {
+                        // Rows missing from the UIColor sheet throw on RowRef.Value, which would
+                        // drop the whole message; keep the previous color instead as we don't
+                        // want invisible text.
+                        if (foregroundPayload.UIColor.ValueNullable is { } foregroundRow)
+                            foreground.Push(foregroundRow.Dark);
+                        else if (foreground.Count > 0)
+                            foreground.Push(foreground.Peek());
+                    }
                     else if (foreground.Count > 0)
+                    {
                         foreground.Pop();
+                    }
                     break;
                 case PayloadType.UIGlow:
                     var glowPayload = (UIGlowPayload) payload;
                     if (glowPayload.IsEnabled)
-                        glow.Push(glowPayload.UIColor.Value.Dark);
+                    {
+                        // Rows missing from the UIColor sheet throw on RowRef.Value, which would
+                        // drop the whole message; push a no-glow entry to keep the stack balanced.
+                        glow.Push(glowPayload.UIColor.ValueNullable?.Dark ?? 0);
+                    }
                     else if (glow.Count > 0)
+                    {
                         glow.Pop();
+                    }
                     break;
                 case PayloadType.AutoTranslateText:
                     chunks.Add(new IconChunk(source, payload, BitmapFontIcon.AutoTranslateBegin));
@@ -328,16 +344,19 @@ public static class ChunkUtil
                             foreground.Pop();
                         }
                     }
-                    else if (rawPayload.Data.Length > 1 && rawPayload.Data[1] == 0x14)
+                    else if (ColorPayload.From(rawPayload.Data, MacroCode.EdgeColor) is { } edgeColorPayload)
                     {
-                        if (glow.Count > 0)
+                        if (edgeColorPayload.Enabled)
+                        {
+                            // The game pushes the resolved value even when it is 0, which draws
+                            // no outline (verified against the vanilla renderer). A 0 entry keeps
+                            // the stack balanced for the matching stackcolor pop; unlike the
+                            // foreground there is no invisible-text concern.
+                            glow.Push(edgeColorPayload.Color);
+                        }
+                        else if (glow.Count > 0)
                         {
                             glow.Pop();
-                        }
-                        else if (rawPayload.Data.Length > 6 && rawPayload.Data[2] == 0x05 && rawPayload.Data[3] == 0xF6)
-                        {
-                            var (r, g, b) = (rawPayload.Data[4], rawPayload.Data[5], rawPayload.Data[6]);
-                            glow.Push(ColourUtil.ComponentsToRgba(r, g, b));
                         }
                     }
                     else if (rawPayload.Data.Length > 7 && rawPayload.Data[1] == 0x27 && rawPayload.Data[3] == 0x0A)

--- a/ChatTwo/Util/ChunkUtil.cs
+++ b/ChatTwo/Util/ChunkUtil.cs
@@ -287,7 +287,7 @@ public static class ChunkUtil
                 case PayloadType.UIGlow:
                     var glowPayload = (UIGlowPayload) payload;
                     if (glowPayload.IsEnabled)
-                        glow.Push(glowPayload.UIColor.Value.Light);
+                        glow.Push(glowPayload.UIColor.Value.Dark);
                     else if (glow.Count > 0)
                         glow.Pop();
                     break;

--- a/ChatTwo/Util/ColourUtil.cs
+++ b/ChatTwo/Util/ColourUtil.cs
@@ -68,9 +68,10 @@ public static class ColourUtil
         if (col == 0)
             return 0;
 
-        // Check if Alpha is set, if not set to 255
-        if (col <= 0x00FFFFFFu)
-            col |= 0xFF000000u;
+        // The game ignores the alpha of pushed colors entirely and renders them
+        // fully opaque (verified against the vanilla renderer), so force alpha
+        // regardless of what the payload carries.
+        col |= 0xFF000000u;
 
         var buf = (byte*)&col;
         (buf[1], buf[2], buf[3], buf[0]) = (buf[0], buf[1], buf[2], buf[3]);

--- a/ChatTwo/Util/ColourUtil.cs
+++ b/ChatTwo/Util/ColourUtil.cs
@@ -40,6 +40,14 @@ public static class ColourUtil
         => ComponentsToRgba((byte)Math.Round(col.X * 255), (byte)Math.Round(col.Y * 255), (byte)Math.Round(col.Z * 255));
 
     /// <summary>
+    /// Converts a Vector4 to an RGBA color value.
+    /// </summary>
+    /// <param name="col">The color</param>
+    /// <returns>Color as byte representation RR GG BB AA</returns>
+    public static uint Vector4ToRgba(Vector4 col)
+        => ComponentsToRgba((byte)Math.Round(col.X * 255), (byte)Math.Round(col.Y * 255), (byte)Math.Round(col.Z * 255), (byte)Math.Round(col.W * 255));
+
+    /// <summary>
     /// Converts a Vector4 to an ABGR color value.
     /// </summary>
     /// <param name="col">The color</param>

--- a/ChatTwo/Util/ExtraPayload.cs
+++ b/ChatTwo/Util/ExtraPayload.cs
@@ -1,4 +1,6 @@
-﻿namespace ChatTwo.Util;
+﻿using Lumina.Text.Payloads;
+
+namespace ChatTwo.Util;
 
 public class ColorPayload
 {
@@ -7,17 +9,18 @@ public class ColorPayload
     public bool Enabled;
     public uint Color;
     public uint UnshiftedColor;
+    public MacroCode MacroCode;
 
-    public static ColorPayload? From(byte[] data)
+    public static ColorPayload? From(byte[] data, MacroCode macroCode = MacroCode.Color)
     {
         using var stream = new MemoryStream(data);
-        if (stream.ReadByte() != StartByte || stream.ReadByte() != 0x13)
+        if (stream.ReadByte() != StartByte || stream.ReadByte() != (byte) macroCode)
             return null;
 
         stream.ReadByte(); // skip the length byte;
 
         var typeByte = stream.ReadByte();
-        var payload = new ColorPayload();
+        var payload = new ColorPayload { MacroCode = macroCode };
         switch (typeByte)
         {
             case 0xEC:
@@ -33,31 +36,46 @@ public class ColorPayload
                 return payload;
             case >= 0xF0 and <= 0xFE:
                 // From: https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/Expressions/IntegerExpression.cs#L119-L128
-                uint ShiftAndThrowIfZero(int v, int shift)
+                // Component bytes are never zero in this encoding, so zero doubles
+                // as the truncation sentinel (EOF or premature null); payload data
+                // comes from the game or other plugins, so malformed input must
+                // return null rather than throw.
+                var truncated = false;
+                uint ReadComponent(int shift)
                 {
-                    return v switch
+                    var v = stream.ReadByte();
+                    if (v <= 0)
                     {
-                        // ReSharper disable once LocalizableElement
-                        -1 => throw new ArgumentException("Encountered premature end of input (unexpected EOF).", nameof(v)),
-                        // ReSharper disable once LocalizableElement
-                        0 => throw new ArgumentException("Encountered premature end of input (unexpected null character).", nameof(v)),
-                        _ => (uint)v << shift,
-                    };
+                        truncated = true;
+                        return 0;
+                    }
+
+                    return (uint) v << shift;
                 }
 
                 typeByte += 1;
                 var argbValue = 0u;
                 if ((typeByte & 8) != 0)
-                    argbValue |= ShiftAndThrowIfZero(stream.ReadByte(), 24);
+                    argbValue |= ReadComponent(24);
                 else
                     argbValue |= 0xFF000000u;
 
-                if( (typeByte & 4) != 0 ) argbValue |= ShiftAndThrowIfZero( stream.ReadByte(), 16 );
-                if( (typeByte & 2) != 0 ) argbValue |= ShiftAndThrowIfZero( stream.ReadByte(), 8 );
-                if( (typeByte & 1) != 0 ) argbValue |= ShiftAndThrowIfZero( stream.ReadByte(), 0 );
+                if ((typeByte & 4) != 0) argbValue |= ReadComponent(16);
+                if ((typeByte & 2) != 0) argbValue |= ReadComponent(8);
+                if ((typeByte & 1) != 0) argbValue |= ReadComponent(0);
+
+                if (truncated)
+                    return null;
 
                 payload.Enabled = true;
                 payload.Color = ColourUtil.ArgbToRgba(argbValue);
+
+                return payload;
+            case >= 0x01 and <= 0xCF:
+                // Inline small integer: a single byte encoding value + 1. The game pushes the
+                // resolved value as-is; 0 draws no edge (verified against the vanilla renderer).
+                payload.Enabled = true;
+                payload.Color = ColourUtil.ArgbToRgba((uint) (typeByte - 1));
 
                 return payload;
             default:

--- a/ChatTwo/Util/ImGuiUtil.cs
+++ b/ChatTwo/Util/ImGuiUtil.cs
@@ -69,11 +69,12 @@ public static class ImGuiUtil
     {
         if (Plugin.Config.RenderGlow && chunk is TextChunk { Glow: not null and not 0 } text)
         {
-            // Game glow colours are fully opaque; scale the alpha so the composite
-            // opacity across the 8 outline stamps matches the vanilla glow (~85%).
-            var glow = text.Glow.Value;
-            var alpha = (byte) ((glow & 0xFF) * 0x66 / 0xFF);
-            return (glow & 0xFFFFFF00u) | alpha;
+            // The game ignores the alpha of pushed edge colours entirely (both
+            // EdgeColorType sheet lookups and raw EdgeColor values render fully
+            // opaque), so don't derive anything from the source alpha. Use the
+            // fixed per-stamp alpha whose composite over the 8 outline stamps
+            // matches the vanilla glow (~85%).
+            return (text.Glow.Value & 0xFFFFFF00u) | 0x66;
         }
 
         return Plugin.Config.OutlineAllText ? Plugin.Config.OutlineColor : null;

--- a/ChatTwo/Util/ImGuiUtil.cs
+++ b/ChatTwo/Util/ImGuiUtil.cs
@@ -59,11 +59,62 @@ public static class ImGuiUtil
                 handler.Click(chunk, payload, button);
     }
 
+    /// <summary>
+    /// Resolves the effective glow (outline) colour for a chunk, combining
+    /// the game-specified glow payload with the outline all text option.
+    /// </summary>
+    /// <param name="chunk">The chunk about to be drawn</param>
+    /// <returns>Colour as byte representation RR GG BB AA, or null if no outline should be drawn</returns>
+    public static uint? GetGlowColor(Chunk chunk)
+    {
+        if (Plugin.Config.RenderGlow && chunk is TextChunk { Glow: not null and not 0 } text)
+        {
+            // Game glow colours are fully opaque; scale the alpha so the composite
+            // opacity across the 8 outline stamps matches the vanilla glow (~85%).
+            var glow = text.Glow.Value;
+            var alpha = (byte) ((glow & 0xFF) * 0x66 / 0xFF);
+            return (glow & 0xFFFFFF00u) | alpha;
+        }
+
+        return Plugin.Config.OutlineAllText ? Plugin.Config.OutlineColor : null;
+    }
+
+    /// <summary>
+    /// Draws a text outline by rendering the text into the window draw list,
+    /// offset by a pixel in each direction. Call this before drawing the text
+    /// itself so the outline stays underneath it.
+    /// </summary>
+    /// <param name="pos">Screen position the text will be drawn at</param>
+    /// <param name="rgba">Outline colour as byte representation RR GG BB AA</param>
+    /// <param name="text">UTF-8 text about to be drawn</param>
+    public static void DrawTextGlow(Vector2 pos, uint rgba, ReadOnlySpan<byte> text)
+    {
+        // Style alpha (e.g. faded windows) is applied to regular text items
+        // but not to raw draw list commands, so bake it into the colour.
+        var colour = ColourUtil.RgbaToVector4(rgba)!.Value;
+        colour.W *= ImGui.GetStyle().Alpha;
+        if (colour.W <= 0)
+            return;
+
+        var abgr = ColourUtil.Vector4ToAbgr(colour);
+        var drawList = ImGui.GetWindowDrawList();
+        var offset = ImGuiHelpers.GlobalScale;
+        for (var x = -1; x <= 1; x++)
+            for (var y = -1; y <= 1; y++)
+                if (x != 0 || y != 0)
+                    drawList.AddText(pos + new Vector2(x, y) * offset, abgr, text);
+    }
+
     public static unsafe void WrapText(string csText, Chunk chunk, PayloadHandler? handler, Vector4 defaultText, float lineWidth)
     {
+        var glow = GetGlowColor(chunk);
+
         void Text(byte* text, byte* textEnd)
         {
             var oldPos = ImGui.GetCursorScreenPos();
+
+            if (glow != null)
+                DrawTextGlow(oldPos, glow.Value, new ReadOnlySpan<byte>(text, (int) (textEnd - text)));
 
             ImGuiNative.TextUnformatted(text, textEnd);
             PostPayload(chunk, handler);


### PR DESCRIPTION
## What

- **Render game-specified glow colours as text outlines.** Chat messages that carry a `UIGlow` payload (e.g. the red "Dalamud" in the welcome message, duty/collectable notices) now render with their outline in Chat 2, matching vanilla chat. Toggleable via a new *Render glow* option (on by default).
- **New "Outline all text" option** (off by default): draws a configurable outline around all chat text for readability, with a colour picker and a reset button in the Fonts settings tab.

## How

The outline is drawn by stamping the text into the window draw list 8 times at ±1px offsets before the text itself is drawn (`ImGuiUtil.DrawTextGlow`).

Two details were needed to actually match vanilla rendering (verified by pixel-level comparison of vanilla vs Chat 2 screenshots):

1. **Glow colours resolve via the dark-theme `UIColor` variant.** The `UIColor` sheet columns (`Dark`, `Light`, `ClassicFF`, …) are per-UI-theme variants of one colour. Using `.Light` yields pastel light-theme colours (a red glow rendered as salmon-pink); `.Dark` matches what vanilla chat displays, consistent with how foreground colours are already resolved.
2. **Glow alpha is scaled by 0x66/0xFF per stamp.** Vanilla's glow peaks at ~85% opacity with a soft falloff. Game glow payloads are fully opaque, and overlapping stamps compound alpha (two stamps at 85% already composite to ~98%), producing a hard solid ring instead of a glow. Scaling each stamp to 0x66 makes the composite across overlapping stamps land at vanilla's ~85% peak — measured within ~1% of vanilla on identical test messages. The default outline colour for *Outline all text* is `0x00000066` for the same reason.

Disclosure:
This was co-developed with AI assistance (Claude Code).
I've reviewed the code and tested it in game myself.

## Screenshots

| Vanilla | Chat 2 |
|---|---|
| <img width="626" height="850" alt="2026-07-06_03-33-51_ffxiv_dx11_el67hBtiLB" src="https://github.com/user-attachments/assets/511e1614-f723-41b2-904b-88a622e64a82" /> | <img width="664" height="958" alt="2026-07-06_03-33-42_ffxiv_dx11_N5AF5PjTl2" src="https://github.com/user-attachments/assets/789bd786-646e-402a-bd36-0ce8f8f1e096" /> |