### PR TITLE
Add per-tab option to set a default input channel without locking it

### DIFF
--- a/ChatTwo/Configuration.cs
+++ b/ChatTwo/Configuration.cs
@@ -258,6 +258,7 @@ public class Tab
     public bool UnhideOnActivity;
     public bool DisplayTimestamp = true;
     public InputChannel? Channel;
+    public bool LockChannel = true;
     public bool PopOut;
     public bool IndependentOpacity;
     public float Opacity = 100f;
@@ -342,6 +343,7 @@ public class Tab
             LastActivity = LastActivity,
             DisplayTimestamp = DisplayTimestamp,
             Channel = Channel,
+            LockChannel = LockChannel,
             PopOut = PopOut,
             IndependentOpacity = IndependentOpacity,
             Opacity = Opacity,

--- a/ChatTwo/Resources/Language.Designer.cs
+++ b/ChatTwo/Resources/Language.Designer.cs
@@ -3517,6 +3517,15 @@ namespace ChatTwo.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lock input channel.
+        /// </summary>
+        internal static string Options_Tabs_LockChannel {
+            get {
+                return ResourceManager.GetString("Options_Tabs_LockChannel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Move down.
         /// </summary>
         internal static string Options_Tabs_MoveDown {

--- a/ChatTwo/Resources/Language.resx
+++ b/ChatTwo/Resources/Language.resx
@@ -241,6 +241,9 @@
     <data name="Options_Tabs_InputChannel">
         <value>Input channel</value>
     </data>
+    <data name="Options_Tabs_LockChannel">
+        <value>Lock input channel</value>
+    </data>
     <data name="Options_Tabs_Channels">
         <value>Channels</value>
     </data>

--- a/ChatTwo/Ui/ChatLog/ChatLog.Window.cs
+++ b/ChatTwo/Ui/ChatLog/ChatLog.Window.cs
@@ -37,6 +37,7 @@ public partial class ChatLog : Window, IChatWindow
     private bool WasDocked;
 
     private bool DrewThisFrame;
+    private DateTime? ApplyDefaultChannelAt;
 
     public bool IsHidden;
     public HideState CurrentHideState { get; set; } = HideState.None;
@@ -91,6 +92,7 @@ public partial class ChatLog : Window, IChatWindow
     private void Login()
     {
         Plugin.MessageManager.FilterAllTabsAsync();
+        ApplyDefaultChannelAt = DateTime.UtcNow.AddSeconds(3);
     }
 
     public unsafe void Activated(ChatActivatedArgs args)
@@ -375,8 +377,15 @@ public partial class ChatLog : Window, IChatWindow
 
         var activeTab = Plugin.CurrentTab;
 
-        // This tab has a fixed channel, so we force this channel to be always set as current
-        if (activeTab.Channel is not null)
+        if (ApplyDefaultChannelAt is { } applyAt && DateTime.UtcNow >= applyAt)
+        {
+            ApplyDefaultChannelAt = null;
+            if (activeTab.Channel is not null && !activeTab.LockChannel)
+                Plugin.Functions.Chat.SetChannelWithExtraChat(activeTab.Channel);
+        }
+
+        // This tab has a locked channel, so we force this channel to be always set as current
+        if (activeTab.Channel is not null && activeTab.LockChannel)
             activeTab.CurrentChannel.SetChannel(activeTab.Channel.Value);
 
         if (Plugin.Config.PreviewPosition is PreviewPosition.Inside && Plugin.InputPreview.IsDrawable)
@@ -385,10 +394,11 @@ public partial class ChatLog : Window, IChatWindow
         using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, Vector2.Zero))
             DrawChannelName(activeTab);
 
-        if (ImGuiUtil.IconButton(FontAwesomeIcon.Comment) && activeTab.Channel is null)
+        var switcherDisabled = activeTab.Channel is not null && activeTab.LockChannel;
+        if (ImGuiUtil.IconButton(FontAwesomeIcon.Comment) && !switcherDisabled)
             ImGui.OpenPopup(ChatChannelPicker);
 
-        if (activeTab.Channel is not null && ImGui.IsItemHovered())
+        if (switcherDisabled && ImGui.IsItemHovered())
             ImGuiUtil.Tooltip(Language.ChatLog_SwitcherDisabled);
 
         using (var popup = ImRaii.Popup(ChatChannelPicker))

--- a/ChatTwo/Ui/SettingsTabs/Tabs.cs
+++ b/ChatTwo/Ui/SettingsTabs/Tabs.cs
@@ -162,6 +162,9 @@ public sealed class Tabs : ISettingsTab
                     }
                 }
 
+                if (tab.Channel is not null)
+                    ImGui.Checkbox(Language.Options_Tabs_LockChannel, ref tab.LockChannel);
+
                 var player = Plugin.ObjectTable.LocalPlayer;
                 if (tab.Channel == InputChannel.Tell && player != null)
                 {


### PR DESCRIPTION
Right now a tab's "Input channel" is enforced every frame and the channel switcher is disabled. With no input channel set, the tab just inherits whatever channel the game picks on login, which is usually Novice Network.

This adds a "Lock input channel" checkbox per tab. It defaults to on, so existing configs behave exactly as before.

When unchecked, the selected channel is applied when switching to the tab and a few seconds after login, but you can still change the channel afterwards through the switcher, keybinds or commands.

Changes:
- New `LockChannel` field on `Tab` (default `true`, no config migration needed)
- Skip the per-frame channel enforcement and enable the switcher when the tab is unlocked
- Apply the tab's channel shortly after login, since the game switches to Novice Network a moment after the `Login` event. I used a 3 second delay; if that turns out to be too short on some setups, bumping it to 5 should be safe
- One new localization string
